### PR TITLE
refactor: api 에러 처리 구조 개선

### DIFF
--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -130,6 +130,123 @@ export const ErrorCode = {
 export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode]
 
 /**
+ * 에러 코드별 사용자 친화적 메시지
+ *
+ * @description
+ * 서버에서 반환하는 메시지와 별개로, 프론트엔드에서 일관된 UX를 위해 사용합니다.
+ * - 서버 메시지: 기술적/디버깅 용도
+ * - 클라이언트 메시지: 사용자 친화적 표현
+ *
+ * @example
+ * ```typescript
+ * const message = ErrorMessage[ErrorCode.NICKNAME_ALREADY_EXISTS]
+ * // → '이미 사용 중인 닉네임입니다.'
+ * ```
+ */
+export const ErrorMessage: Record<ErrorCodeType, string> = {
+  // Global - 기본 에러
+  [ErrorCode.INVALID_ENUM_VALUE]: '올바르지 않은 값입니다.',
+  [ErrorCode.INVALID_REQUEST_FORMAT]: '요청 형식이 올바르지 않습니다.',
+  [ErrorCode.STATUS_ALREADY_SET]: '이미 처리된 요청입니다.',
+  [ErrorCode.JSON_SERIALIZATION_ERROR]: '데이터 처리 중 오류가 발생했습니다.',
+  [ErrorCode.INTERNAL_SERVER_ERROR]: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+  [ErrorCode.INVALID_INPUT_VALUE]: '입력값이 올바르지 않습니다.',
+  [ErrorCode.INVALID_TYPE_VALUE]: '입력 형식이 올바르지 않습니다.',
+  [ErrorCode.METHOD_NOT_ALLOWED]: '허용되지 않은 요청입니다.',
+
+  // Global - 인증/인가
+  [ErrorCode.ACCESS_DENIED]: '접근 권한이 없습니다.',
+  [ErrorCode.UNAUTHORIZED]: '로그인이 필요합니다.',
+  [ErrorCode.INVALID_TOKEN]: '인증 정보가 유효하지 않습니다.',
+  [ErrorCode.EXPIRED_TOKEN]: '인증이 만료되었습니다. 다시 로그인해주세요.',
+  [ErrorCode.REFRESH_TOKEN_NOT_FOUND]: '인증 정보를 찾을 수 없습니다.',
+
+  // Global - 파일 업로드
+  [ErrorCode.FILE_UPLOAD_FAILED]: '파일 업로드에 실패했습니다.',
+  [ErrorCode.INVALID_FILE_TYPE]: '지원하지 않는 파일 형식입니다.',
+  [ErrorCode.FILE_SIZE_EXCEEDED]: '파일 크기가 너무 큽니다.',
+
+  // Global - 외부 API
+  [ErrorCode.EXTERNAL_API_ERROR]: '외부 서비스 연결에 실패했습니다.',
+  [ErrorCode.KAKAO_API_ERROR]: '카카오 서비스 연결에 실패했습니다.',
+
+  // User
+  [ErrorCode.USER_NOT_FOUND]: '사용자를 찾을 수 없습니다.',
+  [ErrorCode.NICKNAME_ALREADY_EXISTS]: '이미 사용 중인 닉네임입니다.',
+  [ErrorCode.NICKNAME_EMPTY]: '닉네임을 입력해주세요.',
+  [ErrorCode.NICKNAME_LENGTH_INVALID]: '닉네임은 2자 이상 20자 이하로 입력해주세요.',
+  [ErrorCode.NICKNAME_FORMAT_INVALID]: '닉네임은 한글, 영문, 숫자만 사용할 수 있습니다.',
+
+  // Book
+  [ErrorCode.BOOK_NOT_FOUND]: '책을 찾을 수 없습니다.',
+  [ErrorCode.BOOK_ALREADY_EXISTS]: '이미 책장에 등록된 책입니다.',
+  [ErrorCode.BOOK_NOT_IN_SHELF]: '책장에 없는 책입니다.',
+  [ErrorCode.BOOK_REVIEW_NOT_FOUND]: '리뷰를 찾을 수 없습니다.',
+  [ErrorCode.BOOK_REVIEW_ALREADY_EXISTS]: '이미 리뷰를 작성했습니다.',
+  [ErrorCode.KEYWORD_NOT_FOUND]: '키워드를 찾을 수 없습니다.',
+  [ErrorCode.KEYWORD_NOT_SELECTABLE]: '선택할 수 없는 키워드입니다.',
+  [ErrorCode.BOOK_REVIEW_INVALID_RATING]: '별점은 0.5 단위로 5점까지 입력할 수 있습니다.',
+  [ErrorCode.BOOK_REVIEW_DELETED]: '삭제된 리뷰입니다.',
+
+  // Record
+  [ErrorCode.INVALID_RECORD_REQUEST]: '기록 정보가 올바르지 않습니다.',
+  [ErrorCode.INVALID_RECORD_TYPE]: '올바르지 않은 기록 유형입니다.',
+  [ErrorCode.RECORD_NOT_FOUND]: '기록을 찾을 수 없습니다.',
+
+  // Gathering
+  [ErrorCode.GATHERING_NOT_FOUND]: '모임을 찾을 수 없습니다.',
+  [ErrorCode.NOT_GATHERING_MEMBER]: '모임 멤버가 아닙니다.',
+  [ErrorCode.NOT_GATHERING_LEADER]: '모임장만 할 수 있는 작업입니다.',
+  [ErrorCode.ALREADY_INACTIVE]: '이미 비활성화된 모임입니다.',
+  [ErrorCode.CANNOT_REMOVE_LEADER]: '모임장은 강퇴할 수 없습니다.',
+  [ErrorCode.ALREADY_REMOVED_MEMBER]: '이미 강퇴된 멤버입니다.',
+  [ErrorCode.INVITATION_CODE_GENERATION_FAILED]:
+    '초대 코드 생성에 실패했습니다. 다시 시도해주세요.',
+  [ErrorCode.ALREADY_GATHERING_MEMBER]: '이미 가입된 모임입니다.',
+  [ErrorCode.JOIN_REQUEST_ALREADY_PENDING]: '이미 가입 요청 중입니다.',
+  [ErrorCode.INVALID_INVITATION_LINK]: '유효하지 않은 초대 링크입니다.',
+  [ErrorCode.NOT_PENDING_STATUS]: '대기 중인 요청만 처리할 수 있습니다.',
+  [ErrorCode.INVALID_APPROVE_TYPE]: '올바르지 않은 승인 상태입니다.',
+
+  // Meeting
+  [ErrorCode.MEETING_NOT_FOUND]: '약속을 찾을 수 없습니다.',
+  [ErrorCode.MEETING_GATHERING_NOT_FOUND]: '약속의 모임을 찾을 수 없습니다.',
+  [ErrorCode.NOT_GATHERING_MEETING]: '해당 모임의 약속이 아닙니다.',
+  [ErrorCode.NOT_MEETING_MEMBER]: '약속 참가자가 아닙니다.',
+  [ErrorCode.MEETING_MEMBER_NOT_FOUND]: '약속 참가자를 찾을 수 없습니다.',
+  [ErrorCode.NOT_MEETING_LEADER]: '약속장만 할 수 있는 작업입니다.',
+  [ErrorCode.MEETING_ALREADY_CONFIRMED]: '이미 확정된 약속입니다.',
+  [ErrorCode.MEETING_FULL]: '약속 정원이 마감되었습니다.',
+  [ErrorCode.INVALID_MEETING_STATUS_CHANGE]: '약속 상태를 변경할 수 없습니다.',
+  [ErrorCode.MEETING_ALREADY_JOINED]: '이미 참가한 약속입니다.',
+  [ErrorCode.MEETING_ALREADY_CANCELED]: '이미 취소된 약속입니다.',
+  [ErrorCode.MEETING_CANCEL_NOT_ALLOWED]: '약속 시작 24시간 이내에는 취소할 수 없습니다.',
+  [ErrorCode.INVALID_MAX_PARTICIPANTS]: '참가 인원 설정이 올바르지 않습니다.',
+  [ErrorCode.MAX_PARTICIPANTS_LESS_THAN_CURRENT]:
+    '현재 참가 인원보다 적게 설정할 수 없습니다.',
+
+  // Topic
+  [ErrorCode.TOPIC_NOT_FOUND]: '주제를 찾을 수 없습니다.',
+  [ErrorCode.TOPIC_NOT_IN_MEETING]: '해당 약속의 주제가 아닙니다.',
+  [ErrorCode.TOPIC_ANSWER_NOT_FOUND]: '답변을 찾을 수 없습니다.',
+  [ErrorCode.TOPIC_ANSWER_ALREADY_SUBMITTED]: '이미 제출한 답변입니다.',
+  [ErrorCode.TOPIC_USER_CANNOT_DELETE]: '주제를 삭제할 권한이 없습니다.',
+  [ErrorCode.TOPIC_ALREADY_DELETED]: '이미 삭제된 주제입니다.',
+  [ErrorCode.TOPIC_ANSWER_ALREADY_EXISTS]: '이미 답변이 존재합니다.',
+
+  // Retrospective
+  [ErrorCode.RETROSPECTIVE_ALREADY_EXISTS]: '이미 회고를 작성했습니다.',
+
+  // OAuth2
+  [ErrorCode.INVALID_OAUTH_PROVIDER]: '지원하지 않는 로그인 방식입니다.',
+  [ErrorCode.OAUTH_AUTHENTICATION_FAILED]: '로그인에 실패했습니다.',
+  [ErrorCode.INVALID_USER_PRINCIPAL]: '사용자 정보를 확인할 수 없습니다.',
+  [ErrorCode.INVALID_KAKAO_ID]: '카카오 계정 정보를 확인할 수 없습니다.',
+  [ErrorCode.INVALID_KAKAO_EMAIL]: '카카오 이메일 정보가 올바르지 않습니다.',
+  [ErrorCode.INVALID_KAKAO_RESPONSE]: '카카오 응답이 올바르지 않습니다.',
+} as const
+
+/**
  * API 에러 클래스
  *
  * @description
@@ -182,5 +299,24 @@ export class ApiError extends Error {
    */
   isOneOf(...codes: ErrorCodeType[]): boolean {
     return codes.includes(this.code as ErrorCodeType)
+  }
+
+  /**
+   * 사용자 친화적 에러 메시지 반환
+   *
+   * @description
+   * ErrorMessage 상수에서 메시지를 조회하고, 없으면 서버 메시지를 반환합니다.
+   *
+   * @example
+   * ```typescript
+   * catch (error) {
+   *   if (error instanceof ApiError) {
+   *     showToast(error.userMessage)
+   *   }
+   * }
+   * ```
+   */
+  get userMessage(): string {
+    return ErrorMessage[this.code as ErrorCodeType] ?? this.message
   }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,5 @@
 export { api, apiClient } from './client'
 export type { ErrorCodeType } from './errors'
-export { ApiError, ErrorCode } from './errors'
+export { ApiError, ErrorCode, ErrorMessage } from './errors'
 export { setupInterceptors } from './interceptors'
 export type { ApiErrorResponse, ApiResponse, PaginatedResponse } from './types'


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

API 에러 처리를 공통 처리와 별도 처리로 분리하고, 에러 코드별 메시지를 상수로 관리하여 일관된 사용자 경험을 제공합니다.

### 현재 문제점
- 에러 메시지가 서버 응답에만 의존 → 일관성 없는 UX
- 공통 에러와 비즈니스 에러 구분 없음

### 개선 사항
- 에러 코드별 사용자 친화적 메시지 상수화
- `ApiError.userMessage` getter로 간편한 메시지 조회

## 🔧 변경 사항

### errors.ts
- `ErrorMessage` 상수 추가: 모든 에러 코드에 대한 사용자 친화적 메시지
- `ApiError.userMessage` getter 추가: `ErrorMessage`에서 메시지 조회, 없으면 서버 메시지 반환

### index.ts
- `ErrorMessage` export 추가

### 사용 예시
```typescript
import { ApiError, ErrorCode, ErrorMessage } from '@/api'

// 1. ErrorMessage 직접 사용
const message = ErrorMessage[ErrorCode.NICKNAME_ALREADY_EXISTS]
// → '이미 사용 중인 닉네임입니다.'

// 2. ApiError.userMessage 사용
catch (error) {
  if (error instanceof ApiError) {
    showToast(error.userMessage)
  }
}

// 3. 특정 에러 처리
catch (error) {
  if (error instanceof ApiError) {
    if (error.is(ErrorCode.NICKNAME_ALREADY_EXISTS)) {
      setFieldError('nickname', error.userMessage)
    }
  }
}
```

## 기타
- 추후 토스트와 같은 알림 ui 컴포넌트 도입 후 인터셉터에서 공통 에러 토스트를 표시하도록 확장할 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 오류 메시지에 대한 사용자 친화적 표현이 추가되었습니다.
  * API 오류 처리에서 더욱 명확한 메시지 표시가 가능해졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->