### PR TITLE
[refactor] Tabs 컴포넌트 size prop 중복 제거

### DIFF
--- a/src/shared/ui/Tabs.tsx
+++ b/src/shared/ui/Tabs.tsx
@@ -3,17 +3,21 @@ import * as React from 'react'
 
 import { cn } from '@/shared/lib/utils'
 
+type TabsSize = 'small' | 'medium' | 'large'
+
+const TabsSizeContext = React.createContext<TabsSize>('small')
+
 /**
  * Tabs (탭 네비게이션)
- * - `size`로 탭 크기를 지정합니다: small, medium, large
+ * - `TabsList`의 `size`로 탭 크기를 지정합니다: small, medium, large
  * - `badge`를 사용하면 탭 옆에 숫자 배지가 표시됩니다 (medium, large만 지원)
  * - `value`, `onValueChange`로 controlled 모드로 사용할 수 있습니다.
  * @example
  * ```tsx
  * <Tabs defaultValue="tab1">
  *   <TabsList size="medium">
- *     <TabsTrigger value="tab1" size="medium" badge={12}>전체</TabsTrigger>
- *     <TabsTrigger value="tab2" size="medium" badge={5}>진행중</TabsTrigger>
+ *     <TabsTrigger value="tab1" badge={12}>전체</TabsTrigger>
+ *     <TabsTrigger value="tab2" badge={5}>진행중</TabsTrigger>
  *   </TabsList>
  *   <TabsContent value="tab1">전체 목록</TabsContent>
  *   <TabsContent value="tab2">진행중 목록</TabsContent>
@@ -31,26 +35,31 @@ function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive
 }
 
 interface TabsListProps extends React.ComponentProps<typeof TabsPrimitive.List> {
-  size?: 'small' | 'medium' | 'large'
+  size?: TabsSize
 }
 
 function TabsList({ className, size = 'small', ...props }: TabsListProps) {
   return (
-    <TabsPrimitive.List
-      data-slot="tabs-list"
-      data-size={size}
-      className={cn('inline-flex items-center gap-4', className)}
-      {...props}
-    />
+    <TabsSizeContext.Provider value={size}>
+      <TabsPrimitive.List
+        data-slot="tabs-list"
+        data-size={size}
+        className={cn('inline-flex items-center gap-4', className)}
+        {...props}
+      />
+    </TabsSizeContext.Provider>
   )
 }
 
 interface TabsTriggerProps extends React.ComponentProps<typeof TabsPrimitive.Trigger> {
-  size?: 'small' | 'medium' | 'large'
+  /** TabsList의 size를 override하고 싶을 때만 사용 */
+  size?: TabsSize
   badge?: React.ReactNode
 }
 
-function TabsTrigger({ className, size = 'small', badge, children, ...props }: TabsTriggerProps) {
+function TabsTrigger({ className, size: sizeProp, badge, children, ...props }: TabsTriggerProps) {
+  const sizeFromContext = React.useContext(TabsSizeContext)
+  const size = sizeProp ?? sizeFromContext
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
Context API를 활용하여 TabsList에서 size를 한 번만 지정하면 하위 TabsTrigger가 자동 상속받도록 개선

## 🔧 변경 사항

- TabsSizeContext 추가하여 TabsList → TabsTrigger로 size 자동 전달
- TabsTrigger에서 size prop 지정 불필요 (필요시 override 가능)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Tabs 컴포넌트에 반응형 크기 지원 추가 - TabsList에서 크기(small, medium, large)를 설정하면 모든 하위 탭 트리거가 자동으로 해당 크기 스타일을 적용합니다.

* **개선 사항**
  * 탭 크기별로 배지 렌더링 로직을 최적화하여 small 크기에서는 배지가 표시되지 않습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->