### PR TITLE
feat: Modal 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,12 @@
     "vite": "^7.2.4"
   },
   "dependencies": {
-    "@radix-ui/react-popover": "^1.1.15",
-    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-hover-card": "^1.1.15",
+    "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@18.2.7)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@18.2.7)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-hover-card':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.2.7)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -623,6 +626,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-direction@1.1.1':
@@ -2886,6 +2902,28 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.2.7)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.14)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.2.14)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.2.7)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.2.14)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.2.7)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.2.14)(react@18.2.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.2.7)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.2.7)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.2.7)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.2.14)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.2.14)(react@18.2.0)
+      aria-hidden: 1.2.6
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.7.2(@types/react@18.2.14)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.14
+      '@types/react-dom': 18.2.7
 
   '@radix-ui/react-direction@1.1.1(@types/react@18.2.14)(react@18.2.0)':
     dependencies:

--- a/src/pages/ComponentGuide/ComponentGuidePage.tsx
+++ b/src/pages/ComponentGuide/ComponentGuidePage.tsx
@@ -18,6 +18,16 @@ import { DatePicker } from '@/shared/ui/Datepicker'
 import { FilterDropdown } from '@/shared/ui/FilterDropdown'
 import { Input } from '@/shared/ui/Input'
 import { LikeButton } from '@/shared/ui/LikeButton'
+import {
+  Modal,
+  ModalBody,
+  ModalClose,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  ModalTrigger,
+} from '@/shared/ui/Modal'
 import { NumberedCheckbox, NumberedCheckboxGroup } from '@/shared/ui/NumberedCheckbox'
 import { SearchField } from '@/shared/ui/SearchField'
 import { Select } from '@/shared/ui/Select'
@@ -55,6 +65,7 @@ function ComponentGuidePage() {
     { id: 'filterDropdown', name: 'FilterDropdown', category: '폼' },
     { id: 'starRatingFilter', name: 'StarRatingFilter', category: '폼' },
     { id: 'tabs', name: 'Tabs', category: '내비게이션' },
+    { id: 'modal', name: 'Modal', category: '오버레이' },
   ]
 
   const filteredSections = sections.filter(
@@ -137,6 +148,7 @@ function ComponentGuidePage() {
           {selectedSection === 'filterDropdown' && <FilterDropdownSection />}
           {selectedSection === 'starRatingFilter' && <StarRatingFilterSection />}
           {selectedSection === 'tabs' && <TabsSection />}
+          {selectedSection === 'modal' && <ModalSection />}
         </div>
       </main>
     </div>
@@ -1444,6 +1456,202 @@ function FilterDropdownSection() {
         <div className="typo-caption1 text-grey-600">
           이미 선택된 옵션을 다시 클릭하면 선택이 해제됩니다
         </div>
+      </Showcase>
+    </Section>
+  )
+}
+
+function ModalSection() {
+  return (
+    <Section title="Modal" description="고정 높이와 내부 스크롤을 지원하는 모달 컴포넌트">
+      <Showcase
+        title="기본 사용 (Normal)"
+        description="variant='normal' (600px 너비), Footer 버튼 오른쪽 정렬"
+        code={`<Modal>
+  <ModalTrigger asChild>
+    <Button>모달 열기</Button>
+  </ModalTrigger>
+  <ModalContent variant="normal">
+    <ModalHeader>
+      <ModalTitle>모달 제목</ModalTitle>
+    </ModalHeader>
+    <ModalBody>
+      <p>모달 내용이 들어갑니다.</p>
+    </ModalBody>
+    <ModalFooter>
+      <Button>확인</Button>
+    </ModalFooter>
+  </ModalContent>
+</Modal>`}
+      >
+        <Modal>
+          <ModalTrigger asChild>
+            <Button>Normal 모달 열기</Button>
+          </ModalTrigger>
+          <ModalContent variant="normal">
+            <ModalHeader>
+              <ModalTitle>일반 모달</ModalTitle>
+            </ModalHeader>
+            <ModalBody>
+              <div className="space-y-medium">
+                <p className="typo-body2 text-grey-700">
+                  이것은 기본 너비(600px)의 모달입니다. 높이는 625px로 고정되어 있으며, 내용이 넘칠
+                  경우 Body 영역에서만 스크롤이 발생합니다.
+                </p>
+                <div className="space-y-small">
+                  <Input label="이름" placeholder="이름을 입력하세요" />
+                  <Input label="이메일" placeholder="이메일을 입력하세요" />
+                </div>
+              </div>
+            </ModalBody>
+            <ModalFooter>
+              <ModalClose asChild>
+                <Button>확인</Button>
+              </ModalClose>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      </Showcase>
+
+      <Showcase
+        title="넓은 모달 (Wide)"
+        description="variant='wide' (900px 너비)"
+        code={`<Modal>
+  <ModalTrigger asChild>
+    <Button>Wide 모달 열기</Button>
+  </ModalTrigger>
+  <ModalContent variant="wide">
+    <ModalHeader>
+      <ModalTitle>넓은 모달</ModalTitle>
+    </ModalHeader>
+    <ModalBody>...</ModalBody>
+    <ModalFooter>...</ModalFooter>
+  </ModalContent>
+</Modal>`}
+      >
+        <Modal>
+          <ModalTrigger asChild>
+            <Button>Wide 모달 열기</Button>
+          </ModalTrigger>
+          <ModalContent variant="wide">
+            <ModalHeader>
+              <ModalTitle>넓은 모달</ModalTitle>
+            </ModalHeader>
+            <ModalBody>
+              <div className="space-y-medium">
+                <p className="typo-body2 text-grey-700">
+                  이것은 넓은 너비(900px)의 모달입니다. 더 많은 콘텐츠를 표시하기에 적합합니다.
+                </p>
+                <div className="grid grid-cols-2 gap-medium">
+                  <Input label="이름" placeholder="이름" />
+                  <Input label="이메일" placeholder="이메일" />
+                  <Input label="전화번호" placeholder="전화번호" />
+                  <Input label="주소" placeholder="주소" />
+                </div>
+              </div>
+            </ModalBody>
+            <ModalFooter>
+              <ModalClose asChild>
+                <Button variant="secondary">취소</Button>
+              </ModalClose>
+              <Button>저장</Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      </Showcase>
+
+      <Showcase
+        title="Footer 전체 너비 버튼"
+        description="variant='full' - 버튼 하나가 전체 너비 차지"
+        code={`<ModalFooter variant="full">
+  <Button className="w-full">확인</Button>
+</ModalFooter>`}
+      >
+        <Modal>
+          <ModalTrigger asChild>
+            <Button variant="secondary">Full 버튼 모달</Button>
+          </ModalTrigger>
+          <ModalContent>
+            <ModalHeader>
+              <ModalTitle>알림</ModalTitle>
+            </ModalHeader>
+            <ModalBody>
+              <p className="typo-body2 text-grey-700">
+                Footer에 전체 너비 버튼이 있는 모달입니다. 단일 액션만 필요한 경우에 사용합니다.
+              </p>
+            </ModalBody>
+            <ModalFooter variant="full">
+              <ModalClose asChild>
+                <Button className="w-full">확인</Button>
+              </ModalClose>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      </Showcase>
+
+      <Showcase
+        title="Footer 없음"
+        description="ModalFooter를 생략하면 Footer가 표시되지 않습니다"
+        code={`<ModalContent>
+  <ModalHeader>
+    <ModalTitle>알림</ModalTitle>
+  </ModalHeader>
+  <ModalBody>
+    <p>Footer가 없는 모달입니다.</p>
+  </ModalBody>
+</ModalContent>`}
+      >
+        <Modal>
+          <ModalTrigger asChild>
+            <Button variant="secondary">Footer 없는 모달</Button>
+          </ModalTrigger>
+          <ModalContent>
+            <ModalHeader>
+              <ModalTitle>알림</ModalTitle>
+            </ModalHeader>
+            <ModalBody>
+              <p className="typo-body2 text-grey-700">
+                이 모달은 Footer가 없습니다. 단순한 정보 표시용으로 사용할 수 있습니다.
+              </p>
+            </ModalBody>
+          </ModalContent>
+        </Modal>
+      </Showcase>
+
+      <Showcase
+        title="스크롤 테스트"
+        description="내용이 많을 경우 Body 영역에서만 스크롤 발생"
+        code={`<ModalBody>
+  {/* 긴 내용 - Header/Footer 고정, Body만 스크롤 */}
+</ModalBody>`}
+      >
+        <Modal>
+          <ModalTrigger asChild>
+            <Button variant="secondary">스크롤 테스트</Button>
+          </ModalTrigger>
+          <ModalContent>
+            <ModalHeader>
+              <ModalTitle>긴 내용의 모달</ModalTitle>
+            </ModalHeader>
+            <ModalBody>
+              <div className="space-y-medium">
+                {[...Array(15).keys()].map((i) => (
+                  <Card key={i}>
+                    <p className="typo-body2">
+                      스크롤 테스트용 컨텐츠 #{i + 1}. Header와 Footer는 고정되고, Body 영역에서만
+                      스크롤이 발생합니다.
+                    </p>
+                  </Card>
+                ))}
+              </div>
+            </ModalBody>
+            <ModalFooter variant="full">
+              <ModalClose asChild>
+                <Button className="w-full">닫기</Button>
+              </ModalClose>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
       </Showcase>
     </Section>
   )

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -1,0 +1,294 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { X } from 'lucide-react'
+import * as React from 'react'
+
+import { cn } from '@/shared/lib/utils'
+
+/**
+ * Modal 컴포넌트의 루트
+ *
+ * @description Radix Dialog를 기반으로 한 모달 루트 컴포넌트
+ *
+ * @example
+ * ```tsx
+ * <Modal>
+ *   <ModalTrigger asChild>
+ *     <Button>모달 열기</Button>
+ *   </ModalTrigger>
+ *   <ModalContent variant="normal">
+ *     <ModalHeader>
+ *       <ModalTitle>모달 제목</ModalTitle>
+ *     </ModalHeader>
+ *     <ModalBody>모달 내용</ModalBody>
+ *     <ModalFooter>
+ *       <Button>확인</Button>
+ *     </ModalFooter>
+ *   </ModalContent>
+ * </Modal>
+ * ```
+ */
+function Modal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="modal" {...props} />
+}
+
+/**
+ * Modal을 열기 위한 트리거 컴포넌트
+ */
+function ModalTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="modal-trigger" {...props} />
+}
+
+/**
+ * Modal을 프로그래밍 방식으로 닫기 위한 컴포넌트
+ */
+function ModalClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="modal-close" {...props} />
+}
+
+const modalContentVariants = cva(
+  [
+    'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2',
+    'flex flex-col bg-white rounded-small',
+    'h-[625px]',
+    'data-[state=open]:animate-in data-[state=closed]:animate-out',
+    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+    'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+    'focus:outline-none',
+  ].join(' '),
+  {
+    variants: {
+      variant: {
+        normal: 'w-[600px]',
+        wide: 'w-[900px]',
+      },
+    },
+    defaultVariants: {
+      variant: 'normal',
+    },
+  }
+)
+
+export interface ModalContentProps
+  extends
+    React.ComponentProps<typeof DialogPrimitive.Content>,
+    VariantProps<typeof modalContentVariants> {}
+
+/**
+ * Modal의 콘텐츠 컨테이너
+ *
+ * @description
+ * - `normal`: 600px 너비 (기본값)
+ * - `wide`: 900px 너비
+ * - 높이는 625px로 고정
+ *
+ * @example
+ * ```tsx
+ * <ModalContent variant="wide">
+ *   <ModalHeader>
+ *     <ModalTitle>넓은 모달</ModalTitle>
+ *   </ModalHeader>
+ *   <ModalBody>내용</ModalBody>
+ * </ModalContent>
+ * ```
+ */
+function ModalContent({ className, variant, children, ...props }: ModalContentProps) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay
+        data-slot="modal-overlay"
+        className={cn(
+          'fixed inset-0 z-50 bg-black/60',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out',
+          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
+        )}
+      />
+      <DialogPrimitive.Content
+        data-slot="modal-content"
+        className={cn(modalContentVariants({ variant, className }))}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  )
+}
+
+export interface ModalHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** 닫기 버튼 숨김 여부 */
+  hideCloseButton?: boolean
+}
+
+/**
+ * Modal의 헤더 영역
+ *
+ * @description 타이틀과 닫기 버튼을 포함하는 고정 높이 헤더
+ *
+ * @example
+ * ```tsx
+ * <ModalHeader>
+ *   <ModalTitle>모달 제목</ModalTitle>
+ * </ModalHeader>
+ *
+ * // 닫기 버튼 숨기기
+ * <ModalHeader hideCloseButton>
+ *   <ModalTitle>모달 제목</ModalTitle>
+ * </ModalHeader>
+ * ```
+ */
+function ModalHeader({ className, hideCloseButton = false, children, ...props }: ModalHeaderProps) {
+  return (
+    <div
+      data-slot="modal-header"
+      className={cn(
+        'flex items-center justify-between shrink-0',
+        'px-xlarge pt-[36px] pb-base',
+        className
+      )}
+      {...props}
+    >
+      <div className="flex-1">{children}</div>
+      {!hideCloseButton && (
+        <DialogPrimitive.Close
+          data-slot="modal-close-button"
+          className={cn('text-grey-600 cursor-pointer', 'transition-colors focus:outline-none')}
+        >
+          <X className="size-6" />
+          <span className="sr-only">닫기</span>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Modal의 타이틀 컴포넌트
+ *
+ * @example
+ * ```tsx
+ * <ModalTitle>모달 제목</ModalTitle>
+ * ```
+ */
+function ModalTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="modal-title"
+      className={cn('typo-heading3 text-black', className)}
+      {...props}
+    />
+  )
+}
+
+/**
+ * Modal의 설명 컴포넌트 (접근성용)
+ *
+ * @example
+ * ```tsx
+ * <ModalDescription>모달에 대한 설명</ModalDescription>
+ * ```
+ */
+function ModalDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="modal-description"
+      className={cn('typo-body2 text-grey-600', className)}
+      {...props}
+    />
+  )
+}
+
+/**
+ * Modal의 본문 영역
+ *
+ * @description
+ * Header와 Footer를 제외한 나머지 공간을 차지하며,
+ * 내용이 넘칠 경우 세로 스크롤이 발생합니다.
+ *
+ * @example
+ * ```tsx
+ * <ModalBody>
+ *   <p>모달의 주요 내용이 들어갑니다.</p>
+ * </ModalBody>
+ * ```
+ */
+function ModalBody({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot="modal-body"
+      className={cn('flex-1 overflow-y-auto px-xlarge py-xsmall custom-scroll', className)}
+      {...props}
+    />
+  )
+}
+
+const modalFooterVariants = cva(
+  ['flex items-center shrink-0', 'px-xlarge pt-base pb-large border-t border-grey-300'],
+  {
+    variants: {
+      variant: {
+        double: 'justify-end gap-small',
+        full: 'justify-stretch',
+      },
+    },
+    defaultVariants: {
+      variant: 'double',
+    },
+  }
+)
+
+export interface ModalFooterProps
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof modalFooterVariants> {}
+
+/**
+ * Modal의 푸터 영역
+ *
+ * @description 액션 버튼들이 위치하는 선택적 고정 영역
+ *
+ * - `double`: 버튼을 오른쪽 정렬 (기본값)
+ * - `full`: 버튼이 전체 너비 차지
+ *
+ * @example
+ * ```tsx
+ * // 버튼 하나 오른쪽 정렬 (기본)
+ * <ModalFooter>
+ *   <Button>확인</Button>
+ * </ModalFooter>
+ *
+ * // 버튼 두 개 오른쪽 정렬
+ * <ModalFooter>
+ *   <ModalClose asChild>
+ *     <Button variant="secondary">취소</Button>
+ *   </ModalClose>
+ *   <Button>확인</Button>
+ * </ModalFooter>
+ *
+ * // 버튼 하나 전체 너비
+ * <ModalFooter variant="full">
+ *   <Button className="w-full">확인</Button>
+ * </ModalFooter>
+ * ```
+ */
+function ModalFooter({ className, variant, ...props }: ModalFooterProps) {
+  return (
+    <div
+      data-slot="modal-footer"
+      className={cn(modalFooterVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+export {
+  Modal,
+  ModalBody,
+  ModalClose,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  ModalTrigger,
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

shadcn 기반 Modal 컴포넌트 구현

## 📸 스크린샷
<img width="626" height="648" alt="image" src="https://github.com/user-attachments/assets/a5bada87-99b7-4235-ba90-446d2d66b62f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 모달 UI 컴포넌트 추가: 표준 크기, 넓은 크기, 전체 너비 푸터, 푸터 없음, 스크롤 가능한 콘텐츠 등 여러 변형을 지원합니다. 헤더, 본문, 푸터 등의 재사용 가능한 부분별 컴포넌트로 구성됩니다.
* 컴포넌트 가이드 업데이트: 모달 사용 예제와 대화형 데모를 추가했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->