### PR TITLE
feat: 공통 기본 레이아웃 마크업 (GNB, MainLayout)

### DIFF
--- a/src/pages/Auth/index.ts
+++ b/src/pages/Auth/index.ts
@@ -1,3 +1,2 @@
-export { default as AuthLayout } from './AuthLayout'
 export { default as LoginPage } from './LoginPage'
 export { default as OnboardingPage } from './OnboardingPage'

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,6 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom'
 
 import {
-  AuthLayout,
   BookDetailPage,
   BookListPage,
   ComponentGuidePage,
@@ -14,7 +13,7 @@ import {
   RecordListPage,
 } from '@/pages'
 import { ROUTES } from '@/shared/constants/routes'
-import { RootLayout } from '@/shared/layout'
+import { AuthLayout, MainLayout, RootLayout } from '@/shared/layout'
 
 import { PrivateRoute } from './PrivateRoute'
 
@@ -24,60 +23,69 @@ export const router = createBrowserRouter([
     element: <ComponentGuidePage />,
   },
   {
-    element: <AuthLayout />,
+    element: <RootLayout />,
     children: [
-      {
-        path: ROUTES.LOGIN,
-        element: <LoginPage />,
-      },
-    ],
-  },
-  {
-    element: <PrivateRoute />,
-    children: [
+      // 인증 페이지 (GNB 없음)
       {
         element: <AuthLayout />,
         children: [
           {
-            path: ROUTES.ONBOARDING,
-            element: <OnboardingPage />,
+            path: ROUTES.LOGIN,
+            element: <LoginPage />,
           },
         ],
       },
+      // 인증 필요한 페이지
       {
-        element: <RootLayout />,
+        element: <PrivateRoute />,
         children: [
+          // 온보딩 (GNB 없음)
           {
-            path: ROUTES.HOME,
-            element: <HomePage />,
+            element: <AuthLayout />,
+            children: [
+              {
+                path: ROUTES.ONBOARDING,
+                element: <OnboardingPage />,
+              },
+            ],
           },
+          // 메인 페이지들 (GNB 있음)
           {
-            path: ROUTES.HOME_ALIAS,
-            element: <Navigate to={ROUTES.HOME} replace />,
-          },
-          {
-            path: ROUTES.BOOKS,
-            element: <BookListPage />,
-          },
-          {
-            path: `${ROUTES.BOOKS}/:id`,
-            element: <BookDetailPage />,
-          },
-          {
-            path: ROUTES.GATHERINGS,
-            element: <GatheringListPage />,
-          },
-          {
-            path: `${ROUTES.GATHERINGS}/:id`,
-            element: <GatheringDetailPage />,
-          },
-          {
-            path: ROUTES.MEETINGS,
-            element: <MeetingListPage />,
-          },
-          {
-            path: ROUTES.RECORDS,
-            element: <RecordListPage />,
+            element: <MainLayout />,
+            children: [
+              {
+                path: ROUTES.HOME,
+                element: <HomePage />,
+              },
+              {
+                path: ROUTES.HOME_ALIAS,
+                element: <Navigate to={ROUTES.HOME} replace />,
+              },
+              {
+                path: ROUTES.BOOKS,
+                element: <BookListPage />,
+              },
+              {
+                path: `${ROUTES.BOOKS}/:id`,
+                element: <BookDetailPage />,
+              },
+              {
+                path: ROUTES.GATHERINGS,
+                element: <GatheringListPage />,
+              },
+              {
+                path: `${ROUTES.GATHERINGS}/:id`,
+                element: <GatheringDetailPage />,
+              },
+              {
+                path: ROUTES.MEETINGS,
+                element: <MeetingListPage />,
+              },
+              {
+                path: ROUTES.RECORDS,
+                element: <RecordListPage />,
+              },
+            ],
           },
         ],
       },

--- a/src/shared/layout/AuthLayout.tsx
+++ b/src/shared/layout/AuthLayout.tsx
@@ -8,8 +8,8 @@ import { Outlet } from 'react-router-dom'
  */
 export default function AuthLayout() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-grey-100">
+    <main className="flex min-h-screen items-center justify-center bg-grey-100">
       <Outlet />
-    </div>
+    </main>
   )
 }

--- a/src/shared/layout/MainLayout.tsx
+++ b/src/shared/layout/MainLayout.tsx
@@ -1,0 +1,22 @@
+import { Outlet } from 'react-router-dom'
+
+import { Header } from './components'
+
+/**
+ * MainLayout (GNB가 있는 페이지 레이아웃)
+ *
+ * - 피그마 디자인 스펙:
+ *   - 전체 너비: 1440px (최대)
+ *   - 좌우 패딩: 120px → 컨텐츠 영역 1200px
+ *   - GNB 아래 여백: 40px (pt-xlarge)
+ */
+export default function MainLayout() {
+  return (
+    <>
+      <Header />
+      <main className="mx-auto max-w-layout-max px-layout-padding pt-xlarge">
+        <Outlet />
+      </main>
+    </>
+  )
+}

--- a/src/shared/layout/RootLayout.tsx
+++ b/src/shared/layout/RootLayout.tsx
@@ -1,27 +1,15 @@
 import { Outlet } from 'react-router-dom'
 
+/**
+ * RootLayout (앱 전체 래퍼)
+ *
+ * - 전역 관심사만 담당 (Provider, 에러바운더리, 토스트 등)
+ * - 시각적 레이아웃은 MainLayout, AuthLayout에서 담당
+ */
 export default function RootLayout() {
   return (
-    <div className="min-h-screen bg-background">
-      <header className="border-b">
-        <nav className="container mx-auto flex h-16 items-center justify-between px-4">
-          <div className="flex items-center gap-8">
-            <h1 className="text-xl font-bold">독크독크</h1>
-            {/* TODO: Add navigation links */}
-          </div>
-          <div>{/* TODO: Add user menu */}</div>
-        </nav>
-      </header>
-
-      <main className="container mx-auto px-4 py-8">
-        <Outlet />
-      </main>
-
-      <footer className="border-t py-6">
-        <div className="container mx-auto px-4 text-center text-sm text-muted-foreground">
-          <p>&copy; 2026 독크독크. All rights reserved.</p>
-        </div>
-      </footer>
+    <div className="min-h-screen bg-white">
+      <Outlet />
     </div>
   )
 }

--- a/src/shared/layout/components/Header.tsx
+++ b/src/shared/layout/components/Header.tsx
@@ -1,0 +1,63 @@
+import { Bell } from 'lucide-react'
+import { Link, NavLink } from 'react-router-dom'
+
+import LogoIcon from '@/shared/assets/images/logo-icon.png'
+import LogoText from '@/shared/assets/images/logo-text.png'
+import { ROUTES } from '@/shared/constants/routes'
+import { cn } from '@/shared/lib/utils'
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui'
+
+const NAV_ITEMS = [
+  { label: '홈', path: ROUTES.HOME },
+  { label: '내 책장', path: ROUTES.BOOKS },
+  { label: '독서모임', path: ROUTES.GATHERINGS },
+] as const
+
+export default function Header() {
+  const handleNotificationClick = () => {
+    alert('준비중입니다.')
+  }
+  return (
+    <header className="h-gnb-height bg-white">
+      <nav className="mx-auto flex h-full max-w-layout-max items-center justify-between px-layout-padding">
+        {/* 좌측: 로고 + 네비게이션 */}
+        <div className="flex items-center gap-11.75">
+          {/* 로고 */}
+          <Link to={ROUTES.HOME} className="flex items-center gap-xsmall">
+            <img src={LogoIcon} alt="" className="h-5.25 w-6.75" />
+            <img src={LogoText} alt="독크독크" className="h-5.25 w-19" />
+          </Link>
+
+          {/* 네비게이션 */}
+          <div className="flex items-center gap-8">
+            {NAV_ITEMS.map((item) => (
+              <NavLink
+                key={item.path}
+                to={item.path}
+                className={({ isActive }) =>
+                  cn('typo-subtitle2 text-grey-700', isActive && 'font-semibold text-black')
+                }
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </div>
+        </div>
+
+        {/* 우측: 알림 + 프로필 */}
+        <div className="flex items-center gap-large">
+          {/* 알림 아이콘 */}
+          <button type="button" className="size-6 cursor-pointer" onClick={handleNotificationClick}>
+            <Bell className="size-full fill-grey-600 stroke-grey-600" />
+          </button>
+
+          {/* 프로필 아바타 */}
+          <Avatar className="size-8">
+            <AvatarImage src="" alt="프로필" />
+            <AvatarFallback />
+          </Avatar>
+        </div>
+      </nav>
+    </header>
+  )
+}

--- a/src/shared/layout/components/index.ts
+++ b/src/shared/layout/components/index.ts
@@ -1,0 +1,1 @@
+export { default as Header } from './Header'

--- a/src/shared/layout/index.ts
+++ b/src/shared/layout/index.ts
@@ -1,1 +1,3 @@
+export { default as AuthLayout } from './AuthLayout'
+export { default as MainLayout } from './MainLayout'
 export { default as RootLayout } from './RootLayout'

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -109,6 +109,11 @@
   --spacing-large: 24px;
   --spacing-xlarge: 40px;
 
+  /* Layout tokens */
+  --spacing-layout-max: 1440px;
+  --spacing-layout-padding: 120px;
+  --spacing-gnb-height: 64px;
+
   /* font-size tokens */
   --text-heading1: 36px;
   --text-heading2: 24px;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

피그마 디자인 스펙에 맞는 공통 레이아웃 시스템을 구축했습니다.

- **GNB(Header)**: 64px 높이, 좌우 120px 패딩
- **MainLayout**: 최대 너비 1440px, 좌우 120px 패딩, GNB 아래 40px 여백
- **RootLayout**: 전역 래퍼로 단순화 (향후 토스트, 에러바운더리 등 확장 포인트)

Related: #34

## 🔧 변경 사항

### 신규 생성
- `src/shared/layout/components/Header.tsx` - GNB 컴포넌트
- `src/shared/layout/MainLayout.tsx` - 메인 레이아웃
- `src/shared/layout/components/index.ts` - Header export

### 수정
- `src/shared/layout/RootLayout.tsx` - 전역 래퍼로 단순화
- `src/shared/layout/index.ts` - MainLayout, AuthLayout export 추가
- `src/shared/styles/theme.css` - 레이아웃 토큰 추가
- `src/routes/index.tsx` - 라우터 구조 변경 (RootLayout → AuthLayout/MainLayout 분기)

### 레이아웃 토큰
```css
--spacing-layout-max: 1440px;
--spacing-layout-padding: 120px;
--spacing-gnb-height: 64px;
```

## 📸 스크린샷 (선택 사항)

<img width="1507" height="784" alt="image" src="https://github.com/user-attachments/assets/541a33be-5fdc-4adc-9bfa-daa03dfe698f" />

## 📄 기타

- 로그인/온보딩 페이지는 AuthLayout 사용 (GNB 없음)
- 인증된 메인 페이지들은 MainLayout 사용 (GNB 있음)
- 알림 버튼은 임시로 alert 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 메인 페이지 상단 네비게이션 추가 - 로고, 페이지 메뉴, 알림 및 사용자 프로필 표시

* **개선**
  * 페이지 레이아웃 구조 재정렬
  * 인증 페이지와 메인 페이지 UI 체계 분리로 시각적 계층 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->