### PR TITLE
[fix] 약속/주제 확정 관련 버그 수정 및 기능 연결

### DIFF
--- a/src/features/meetings/components/MeetingApprovalItem.tsx
+++ b/src/features/meetings/components/MeetingApprovalItem.tsx
@@ -30,7 +30,7 @@ export default function MeetingApprovalItem({ item, gatheringId }: MeetingApprov
   const { meetingName, bookName, nickname, startDateTime, endDateTime, meetingStatus, meetingId } =
     item
 
-  const confirmMutation = useConfirmMeeting()
+  const confirmMutation = useConfirmMeeting(gatheringId)
   const rejectMutation = useRejectMeeting(gatheringId)
   const deleteMutation = useDeleteMeeting(gatheringId)
   const isPending =

--- a/src/features/meetings/components/MeetingDetailButton.tsx
+++ b/src/features/meetings/components/MeetingDetailButton.tsx
@@ -1,5 +1,8 @@
+import { useNavigate } from 'react-router-dom'
+
 import { useCancelJoinMeeting, useJoinMeeting } from '@/features/meetings/hooks'
 import type { MeetingDetailActionStateType } from '@/features/meetings/meetings.types'
+import { ROUTES } from '@/shared/constants/routes'
 import { Button } from '@/shared/ui'
 import { useGlobalModalStore } from '@/store'
 
@@ -7,6 +10,7 @@ interface MeetingDetailButtonProps {
   buttonLabel: string
   isEnabled: boolean
   type: MeetingDetailActionStateType
+  gatheringId: number
   meetingId: number
 }
 
@@ -14,8 +18,10 @@ export default function MeetingDetailButton({
   buttonLabel,
   isEnabled,
   type,
+  gatheringId,
   meetingId,
 }: MeetingDetailButtonProps) {
+  const navigate = useNavigate()
   const joinMutation = useJoinMeeting()
   const cancelJoinMutation = useCancelJoinMeeting()
   const { openError, openConfirm } = useGlobalModalStore()
@@ -25,9 +31,9 @@ export default function MeetingDetailButton({
   const handleClick = async () => {
     if (!isEnabled || isPending) return
 
-    // 약속 수정 - 페이지 이동 예정 (TODO)
+    // 약속 수정
     if (type === 'CAN_EDIT') {
-      // 페이지 이동 로직 추가 예정
+      navigate(ROUTES.MEETING_UPDATE(gatheringId, meetingId))
       return
     }
 

--- a/src/features/meetings/components/MeetingDetailInfo.tsx
+++ b/src/features/meetings/components/MeetingDetailInfo.tsx
@@ -36,8 +36,11 @@ export function MeetingDetailInfo({ meeting }: MeetingDetailInfoProps) {
         {/* 도서 */}
         <dl className="flex gap-base">
           <dt className={DT_VARIANTS}>도서</dt>
-          <dd className="flex flex-col gap-xtiny">
-            <p className="text-black typo-body3">{meeting.book.bookName}</p>
+          <dd className="flex flex-col gap-tiny">
+            <div className="flex flex-col gap-xtiny">
+              <p className="text-black typo-body3">{meeting.book.bookName}</p>
+              <p className="typo-caption1 text-grey-700">{meeting.book.authors}</p>
+            </div>
             <div className="w-[120px] h-[170px] overflow-hidden rounded">
               <img
                 src={meeting.book.thumbnail}

--- a/src/features/meetings/hooks/useConfirmMeeting.ts
+++ b/src/features/meetings/hooks/useConfirmMeeting.ts
@@ -5,8 +5,8 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
-import { ApiError } from '@/api/errors'
-import type { ApiResponse } from '@/api/types'
+import type { ApiError, ApiResponse } from '@/api'
+import { gatheringQueryKeys } from '@/features/gatherings'
 import { confirmMeeting, type ConfirmMeetingResponse } from '@/features/meetings'
 
 import { meetingQueryKeys } from './meetingQueryKeys'
@@ -18,12 +18,13 @@ import { meetingQueryKeys } from './meetingQueryKeys'
  * 약속을 승인하고 관련 쿼리 캐시를 무효화합니다.
  * - 약속 승인 리스트 캐시 무효화
  * - 약속 승인 카운트 캐시 무효화
+ * - 모임 약속 리스트 캐시 무효화
  *
  * @example
- * const confirmMutation = useConfirmMeeting()
+ * const confirmMutation = useConfirmMeeting(gatheringId)
  * confirmMutation.mutate(meetingId)
  */
-export const useConfirmMeeting = () => {
+export const useConfirmMeeting = (gatheringId: number) => {
   const queryClient = useQueryClient()
 
   return useMutation<ApiResponse<ConfirmMeetingResponse>, ApiError, number>({
@@ -33,6 +34,8 @@ export const useConfirmMeeting = () => {
       queryClient.invalidateQueries({
         queryKey: meetingQueryKeys.approvals(),
       })
+      // 모임 약속 리스트 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: gatheringQueryKeys.meetings(gatheringId) })
     },
   })
 }

--- a/src/features/meetings/hooks/useMeetingForm.ts
+++ b/src/features/meetings/hooks/useMeetingForm.ts
@@ -123,11 +123,12 @@ export const useMeetingForm = ({ gatheringMaxCount, initialData }: UseMeetingFor
     const newError: ValidationErrors = {}
 
     if (
-      !formData.bookId ||
-      !formData.bookName ||
-      !formData.bookThumbnail ||
-      !formData.bookAuthors ||
-      !formData.bookPublisher
+      !isEditMode &&
+      (!formData.bookId ||
+        !formData.bookName ||
+        !formData.bookThumbnail ||
+        !formData.bookAuthors ||
+        !formData.bookPublisher)
     ) {
       newError.bookId = '* 도서를 선택해주세요.'
     }

--- a/src/features/meetings/meetings.mock.ts
+++ b/src/features/meetings/meetings.mock.ts
@@ -261,7 +261,7 @@ const mockMeetingDetails: Record<number, GetMeetingDetailResponse> = {
       buttonLabel: '약속이 끝났어요',
       enabled: false,
     },
-    confirmedTopicExpand: true,
+    confirmedTopic: true,
     confirmedTopicDate: '2026-01-20T14:00:00',
   },
   11: {
@@ -269,7 +269,7 @@ const mockMeetingDetails: Record<number, GetMeetingDetailResponse> = {
     progressStatus: 'PRE',
     meetingName: '킥오프 모임',
     meetingStatus: 'CONFIRMED',
-    confirmedTopicExpand: false,
+    confirmedTopic: false,
     confirmedTopicDate: null,
     gathering: {
       gatheringId: 102,

--- a/src/features/meetings/meetings.types.ts
+++ b/src/features/meetings/meetings.types.ts
@@ -215,7 +215,7 @@ export type GetMeetingDetailResponse = {
   /** 약속 진행 상태 */
   progressStatus: MeetingProgressStatus
   /** 주제 확정 여부 */
-  confirmedTopicExpand: boolean
+  confirmedTopic: boolean
   /** 주제 확정 일시 */
   confirmedTopicDate: string | null
   /** 모임 정보 */

--- a/src/features/topics/components/ConfirmTopicModal.tsx
+++ b/src/features/topics/components/ConfirmTopicModal.tsx
@@ -73,7 +73,6 @@ export default function ConfirmTopicModal({
           handleClose()
         },
         onError: (error) => {
-          console.log(error)
           openError('확정 실패', error.userMessage)
         },
       }

--- a/src/features/topics/components/ConfirmTopicModal.tsx
+++ b/src/features/topics/components/ConfirmTopicModal.tsx
@@ -73,6 +73,7 @@ export default function ConfirmTopicModal({
           handleClose()
         },
         onError: (error) => {
+          console.log(error)
           openError('확정 실패', error.userMessage)
         },
       }

--- a/src/features/topics/components/ProposedTopicList.tsx
+++ b/src/features/topics/components/ProposedTopicList.tsx
@@ -12,6 +12,7 @@ type ProposedTopicListProps = {
   onLoadMore: () => void
   gatheringId: number
   meetingId: number
+  confirmedTopic: boolean
 }
 
 export default function ProposedTopicList({
@@ -21,6 +22,7 @@ export default function ProposedTopicList({
   onLoadMore,
   gatheringId,
   meetingId,
+  confirmedTopic,
 }: ProposedTopicListProps) {
   // 무한 스크롤: IntersectionObserver로 다음 페이지 로드
   const observerRef = useInfiniteScroll(onLoadMore, {
@@ -44,11 +46,12 @@ export default function ProposedTopicList({
                 description={topic.description}
                 createdByNickname={topic.createdByInfo.nickname}
                 likeCount={topic.likeCount}
-                isLiked={topic.isLiked}
-                canDelete={topic.canDelete}
+                isLiked={confirmedTopic ? false : topic.isLiked}
+                canDelete={confirmedTopic ? false : topic.canDelete}
                 gatheringId={gatheringId}
                 meetingId={meetingId}
                 topicId={topic.topicId}
+                isLikeDisabled={confirmedTopic}
               />
             </li>
           ))}

--- a/src/features/topics/components/TopicHeader.tsx
+++ b/src/features/topics/components/TopicHeader.tsx
@@ -28,7 +28,6 @@ type TopicHeaderProps = ProposedHeaderProps | ConfirmedHeaderProps
 
 export default function TopicHeader(props: TopicHeaderProps) {
   const navigate = useNavigate()
-  console.log(props.confirmedTopic, props.confirmedTopicDate)
   return (
     <>
       {/* 제안탭 */}

--- a/src/features/topics/components/TopicHeader.tsx
+++ b/src/features/topics/components/TopicHeader.tsx
@@ -28,6 +28,7 @@ type TopicHeaderProps = ProposedHeaderProps | ConfirmedHeaderProps
 
 export default function TopicHeader(props: TopicHeaderProps) {
   const navigate = useNavigate()
+  console.log(props.confirmedTopic, props.confirmedTopicDate)
   return (
     <>
       {/* 제안탭 */}
@@ -64,13 +65,12 @@ export default function TopicHeader(props: TopicHeaderProps) {
               </Button>
             )}
 
-            {props.actions.canSuggest && (
-              <Button
-                onClick={() => navigate(ROUTES.TOPICS_CREATE(props.gatheringId, props.meetingId))}
-              >
-                제안하기
-              </Button>
-            )}
+            <Button
+              onClick={() => navigate(ROUTES.TOPICS_CREATE(props.gatheringId, props.meetingId))}
+              disabled={!props.actions.canSuggest}
+            >
+              제안하기
+            </Button>
           </div>
         </div>
       )}

--- a/src/features/topics/hooks/useConfirmTopics.ts
+++ b/src/features/topics/hooks/useConfirmTopics.ts
@@ -6,6 +6,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { ApiError } from '@/api/errors'
+import { meetingQueryKeys } from '@/features/meetings/hooks/meetingQueryKeys'
 
 import { confirmTopics } from '../topics.api'
 import type { ConfirmTopicsParams, ConfirmTopicsResponse } from '../topics.types'
@@ -54,6 +55,10 @@ export const useConfirmTopics = () => {
           gatheringId: variables.gatheringId,
           meetingId: variables.meetingId,
         }),
+      })
+      // 약속 상세 무효화
+      queryClient.invalidateQueries({
+        queryKey: meetingQueryKeys.detail(variables.meetingId),
       })
     },
   })

--- a/src/features/topics/topics.api.ts
+++ b/src/features/topics/topics.api.ts
@@ -230,14 +230,14 @@ export const confirmTopics = async (
 
   // 🚧 임시: 로그인 기능 개발 전까지 목데이터 사용
   // TODO: 로그인 완료 후 아래 주석을 해제하고 목데이터 로직 제거
-  if (USE_MOCK_DATA) {
+  if (USE_MOCK) {
     // 실제 API 호출을 시뮬레이션하기 위한 지연
     await new Promise((resolve) => setTimeout(resolve, 500))
     return getMockConfirmTopics(meetingId, topicIds)
   }
 
   // 실제 API 호출 (로그인 완료 후 사용)
-  return api.post<ConfirmTopicsResponse>(TOPICS_ENDPOINTS.CONFIRM(gatheringId, meetingId), {
+  return api.patch<ConfirmTopicsResponse>(TOPICS_ENDPOINTS.CONFIRM(gatheringId, meetingId), {
     topicIds,
   })
 }

--- a/src/pages/Meetings/MeetingCreatePage.tsx
+++ b/src/pages/Meetings/MeetingCreatePage.tsx
@@ -154,7 +154,7 @@ export default function MeetingCreatePage() {
       {
         onSuccess: () => {
           openAlert('약속 수정 완료', '약속이 성공적으로 수정되었습니다.', () => {
-            navigate(ROUTES.GATHERING_DETAIL(gatheringId), { replace: true })
+            navigate(ROUTES.MEETING_DETAIL(gatheringId, id), { replace: true })
           })
         },
         onError: (error) => {

--- a/src/pages/Meetings/MeetingDetailPage.tsx
+++ b/src/pages/Meetings/MeetingDetailPage.tsx
@@ -105,6 +105,7 @@ export default function MeetingDetailPage() {
                 buttonLabel={meeting.actionState.buttonLabel}
                 isEnabled={meeting.actionState.enabled}
                 type={meeting.actionState.type}
+                gatheringId={Number(gatheringId)}
                 meetingId={meeting.meetingId}
               />
             </>
@@ -145,7 +146,7 @@ export default function MeetingDetailPage() {
                 <div className="flex flex-col gap-base">
                   <TopicHeader
                     activeTab="PROPOSED"
-                    confirmedTopic={meeting?.confirmedTopicExpand ?? false}
+                    confirmedTopic={meeting?.confirmedTopic ?? false}
                     actions={proposedTopicsInfiniteData.pages[0].actions}
                     confirmedTopicDate={meeting?.confirmedTopicDate ?? null}
                     proposedTopicsCount={proposedTopicsInfiniteData.pages[0].totalCount ?? 0}
@@ -157,6 +158,7 @@ export default function MeetingDetailPage() {
                     topics={proposedTopicsInfiniteData.pages.flatMap(
                       (page: GetProposedTopicsResponse) => page.items
                     )}
+                    confirmedTopic={meeting?.confirmedTopic ?? false}
                     hasNextPage={hasNextProposedPage}
                     isFetchingNextPage={isFetchingNextProposedPage}
                     onLoadMore={fetchNextProposedPage}
@@ -174,7 +176,7 @@ export default function MeetingDetailPage() {
                 <div className="flex flex-col gap-base">
                   <TopicHeader
                     activeTab="CONFIRMED"
-                    confirmedTopic={meeting?.confirmedTopicExpand ?? false}
+                    confirmedTopic={meeting?.confirmedTopic ?? false}
                     actions={confirmedTopicsInfiniteData.pages[0].actions}
                     confirmedTopicDate={meeting?.confirmedTopicDate ?? null}
                   />


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

약속/주제 확정 흐름에서 발생하는 버그를 수정하고 누락된 기능을 연결합니다.

## 🔧 변경 사항

- `confirmedTopicExpand` 필드명을 `confirmedTopic`으로 수정
- 약속 승인 후 모임 약속 리스트 캐시 무효화 추가
- 주제 확정 후 약속 상세 쿼리 캐시 무효화 추가
- 약속 수정 완료 후 약속 상세 페이지로 이동하도록 수정
- 약속 수정 버튼(CAN_EDIT) 클릭 시 수정 페이지로 이동 연결
- 수정 모드에서 도서 선택 유효성 검사 예외 처리
- 주제 확정 시 좋아요/삭제 버튼 비활성화 처리
- 주제 확정 API 메서드 POST → PATCH로 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모임 수정 네비게이션 추가 (모임 상세로 이동)
  * 모임 상세에 책 저자 정보 표시

* **개선사항**
  * 주제 확정 시 제안 목록의 좋아요/삭제 UI 비활성화
  * 모임 생성/수정 후 관련 데이터 캐시 동기화 범위 확대
  * 수정 모드에서 책 관련 입력을 선택 사항으로 완화

* **기타**
  * 주제 확정 API 호출 방식 및 오류 로깅 소소 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->