### PR TITLE
feat: 약속 회고 API 레이어 구축 (#94)

### DIFF
--- a/src/features/retrospectives/hooks/index.ts
+++ b/src/features/retrospectives/hooks/index.ts
@@ -1,0 +1,5 @@
+export * from './retrospectiveQueryKeys'
+export * from './useCreateSttJob'
+export * from './usePublishSummary'
+export * from './useSummary'
+export * from './useUpdateSummary'

--- a/src/features/retrospectives/hooks/retrospectiveQueryKeys.ts
+++ b/src/features/retrospectives/hooks/retrospectiveQueryKeys.ts
@@ -1,0 +1,6 @@
+export const retrospectiveQueryKeys = {
+  all: ['retrospectives'] as const,
+
+  summaries: () => [...retrospectiveQueryKeys.all, 'summary'] as const,
+  summary: (meetingId: number) => [...retrospectiveQueryKeys.summaries(), meetingId] as const,
+}

--- a/src/features/retrospectives/hooks/useCreateSttJob.ts
+++ b/src/features/retrospectives/hooks/useCreateSttJob.ts
@@ -16,11 +16,7 @@ import type { CreateSttJobParams, SttJobResponse } from '../retrospectives.types
 export const useCreateSttJob = () => {
   const abortControllerRef = useRef<AbortController | null>(null)
 
-  const mutation = useMutation<
-    ApiResponse<SttJobResponse>,
-    ApiError,
-    CreateSttJobParams
-  >({
+  const mutation = useMutation<ApiResponse<SttJobResponse>, ApiError, CreateSttJobParams>({
     mutationFn: (params: CreateSttJobParams) => {
       abortControllerRef.current?.abort()
 

--- a/src/features/retrospectives/hooks/useCreateSttJob.ts
+++ b/src/features/retrospectives/hooks/useCreateSttJob.ts
@@ -1,8 +1,7 @@
 import { useMutation } from '@tanstack/react-query'
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import type { ApiError } from '@/api'
-import type { ApiResponse } from '@/api/types'
 
 import { createSttJob } from '../retrospectives.api'
 import type { CreateSttJobParams, SttJobResponse } from '../retrospectives.types'
@@ -12,21 +11,30 @@ import type { CreateSttJobParams, SttJobResponse } from '../retrospectives.types
  *
  * - 동기 API이므로 mutation pending 동안 로딩 오버레이 표시
  * - cancel() 호출 시 진행 중인 HTTP 요청 중단
+ * - 컴포넌트 언마운트 시 자동 취소
  */
 export const useCreateSttJob = () => {
   const abortControllerRef = useRef<AbortController | null>(null)
 
-  const mutation = useMutation<ApiResponse<SttJobResponse>, ApiError, CreateSttJobParams>({
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort()
+      abortControllerRef.current = null
+    }
+  }, [])
+
+  const mutation = useMutation<SttJobResponse, ApiError, CreateSttJobParams>({
     mutationFn: (params: CreateSttJobParams) => {
       abortControllerRef.current?.abort()
 
       const controller = new AbortController()
       abortControllerRef.current = controller
 
-      return createSttJob(params, controller.signal)
-    },
-    onSettled: () => {
-      abortControllerRef.current = null
+      return createSttJob(params, controller.signal).finally(() => {
+        if (abortControllerRef.current === controller) {
+          abortControllerRef.current = null
+        }
+      })
     },
   })
 

--- a/src/features/retrospectives/hooks/useCreateSttJob.ts
+++ b/src/features/retrospectives/hooks/useCreateSttJob.ts
@@ -1,0 +1,46 @@
+import { useMutation } from '@tanstack/react-query'
+import { useCallback, useRef } from 'react'
+
+import type { ApiError } from '@/api'
+import type { ApiResponse } from '@/api/types'
+
+import { createSttJob } from '../retrospectives.api'
+import type { CreateSttJobParams, SttJobResponse } from '../retrospectives.types'
+
+/**
+ * STT Job 생성 (AI 요약 트리거) mutation 훅
+ *
+ * - 동기 API이므로 mutation pending 동안 로딩 오버레이 표시
+ * - cancel() 호출 시 진행 중인 HTTP 요청 중단
+ */
+export const useCreateSttJob = () => {
+  const abortControllerRef = useRef<AbortController | null>(null)
+
+  const mutation = useMutation<
+    ApiResponse<SttJobResponse>,
+    ApiError,
+    CreateSttJobParams
+  >({
+    mutationFn: (params: CreateSttJobParams) => {
+      abortControllerRef.current?.abort()
+
+      const controller = new AbortController()
+      abortControllerRef.current = controller
+
+      return createSttJob(params, controller.signal)
+    },
+    onSettled: () => {
+      abortControllerRef.current = null
+    },
+  })
+
+  const { reset } = mutation
+
+  const cancel = useCallback(() => {
+    abortControllerRef.current?.abort()
+    abortControllerRef.current = null
+    reset()
+  }, [reset])
+
+  return { ...mutation, cancel }
+}

--- a/src/features/retrospectives/hooks/usePublishSummary.ts
+++ b/src/features/retrospectives/hooks/usePublishSummary.ts
@@ -10,17 +10,10 @@ import { retrospectiveQueryKeys } from './retrospectiveQueryKeys'
 export const usePublishSummary = () => {
   const queryClient = useQueryClient()
 
-  return useMutation<
-    ApiResponse<RetrospectiveSummaryResponse>,
-    ApiError,
-    PublishSummaryParams
-  >({
+  return useMutation<ApiResponse<RetrospectiveSummaryResponse>, ApiError, PublishSummaryParams>({
     mutationFn: (params: PublishSummaryParams) => publishSummary(params),
     onSuccess: (response, variables) => {
-      queryClient.setQueryData(
-        retrospectiveQueryKeys.summary(variables.meetingId),
-        response.data
-      )
+      queryClient.setQueryData(retrospectiveQueryKeys.summary(variables.meetingId), response.data)
     },
   })
 }

--- a/src/features/retrospectives/hooks/usePublishSummary.ts
+++ b/src/features/retrospectives/hooks/usePublishSummary.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import type { ApiError } from '@/api'
+import type { ApiResponse } from '@/api/types'
+
+import { publishSummary } from '../retrospectives.api'
+import type { PublishSummaryParams, RetrospectiveSummaryResponse } from '../retrospectives.types'
+import { retrospectiveQueryKeys } from './retrospectiveQueryKeys'
+
+export const usePublishSummary = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    ApiResponse<RetrospectiveSummaryResponse>,
+    ApiError,
+    PublishSummaryParams
+  >({
+    mutationFn: (params: PublishSummaryParams) => publishSummary(params),
+    onSuccess: (response, variables) => {
+      queryClient.setQueryData(
+        retrospectiveQueryKeys.summary(variables.meetingId),
+        response.data
+      )
+    },
+  })
+}

--- a/src/features/retrospectives/hooks/usePublishSummary.ts
+++ b/src/features/retrospectives/hooks/usePublishSummary.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import type { ApiError } from '@/api'
-import type { ApiResponse } from '@/api/types'
 
 import { publishSummary } from '../retrospectives.api'
 import type { PublishSummaryParams, RetrospectiveSummaryResponse } from '../retrospectives.types'
@@ -10,10 +9,10 @@ import { retrospectiveQueryKeys } from './retrospectiveQueryKeys'
 export const usePublishSummary = () => {
   const queryClient = useQueryClient()
 
-  return useMutation<ApiResponse<RetrospectiveSummaryResponse>, ApiError, PublishSummaryParams>({
+  return useMutation<RetrospectiveSummaryResponse, ApiError, PublishSummaryParams>({
     mutationFn: (params: PublishSummaryParams) => publishSummary(params),
-    onSuccess: (response, variables) => {
-      queryClient.setQueryData(retrospectiveQueryKeys.summary(variables.meetingId), response.data)
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData(retrospectiveQueryKeys.summary(variables.meetingId), data)
     },
   })
 }

--- a/src/features/retrospectives/hooks/useSummary.ts
+++ b/src/features/retrospectives/hooks/useSummary.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+
+import type { ApiError } from '@/api'
+
+import { getSummary } from '../retrospectives.api'
+import type { RetrospectiveSummaryResponse } from '../retrospectives.types'
+import { retrospectiveQueryKeys } from './retrospectiveQueryKeys'
+
+export const useSummary = (meetingId: number) => {
+  const isValid = !Number.isNaN(meetingId) && meetingId > 0
+
+  return useQuery<RetrospectiveSummaryResponse, ApiError>({
+    queryKey: retrospectiveQueryKeys.summary(meetingId),
+    queryFn: () => getSummary(meetingId),
+    enabled: isValid,
+  })
+}

--- a/src/features/retrospectives/hooks/useUpdateSummary.ts
+++ b/src/features/retrospectives/hooks/useUpdateSummary.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import type { ApiError } from '@/api'
+import type { ApiResponse } from '@/api/types'
+
+import { updateSummary } from '../retrospectives.api'
+import type { RetrospectiveSummaryResponse, UpdateSummaryParams } from '../retrospectives.types'
+import { retrospectiveQueryKeys } from './retrospectiveQueryKeys'
+
+export const useUpdateSummary = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    ApiResponse<RetrospectiveSummaryResponse>,
+    ApiError,
+    UpdateSummaryParams
+  >({
+    mutationFn: (params: UpdateSummaryParams) => updateSummary(params),
+    onSuccess: (response, variables) => {
+      queryClient.setQueryData(
+        retrospectiveQueryKeys.summary(variables.meetingId),
+        response.data
+      )
+    },
+  })
+}

--- a/src/features/retrospectives/hooks/useUpdateSummary.ts
+++ b/src/features/retrospectives/hooks/useUpdateSummary.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import type { ApiError } from '@/api'
-import type { ApiResponse } from '@/api/types'
 
 import { updateSummary } from '../retrospectives.api'
 import type { RetrospectiveSummaryResponse, UpdateSummaryParams } from '../retrospectives.types'
@@ -10,10 +9,10 @@ import { retrospectiveQueryKeys } from './retrospectiveQueryKeys'
 export const useUpdateSummary = () => {
   const queryClient = useQueryClient()
 
-  return useMutation<ApiResponse<RetrospectiveSummaryResponse>, ApiError, UpdateSummaryParams>({
+  return useMutation<RetrospectiveSummaryResponse, ApiError, UpdateSummaryParams>({
     mutationFn: (params: UpdateSummaryParams) => updateSummary(params),
-    onSuccess: (response, variables) => {
-      queryClient.setQueryData(retrospectiveQueryKeys.summary(variables.meetingId), response.data)
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData(retrospectiveQueryKeys.summary(variables.meetingId), data)
     },
   })
 }

--- a/src/features/retrospectives/hooks/useUpdateSummary.ts
+++ b/src/features/retrospectives/hooks/useUpdateSummary.ts
@@ -10,17 +10,10 @@ import { retrospectiveQueryKeys } from './retrospectiveQueryKeys'
 export const useUpdateSummary = () => {
   const queryClient = useQueryClient()
 
-  return useMutation<
-    ApiResponse<RetrospectiveSummaryResponse>,
-    ApiError,
-    UpdateSummaryParams
-  >({
+  return useMutation<ApiResponse<RetrospectiveSummaryResponse>, ApiError, UpdateSummaryParams>({
     mutationFn: (params: UpdateSummaryParams) => updateSummary(params),
     onSuccess: (response, variables) => {
-      queryClient.setQueryData(
-        retrospectiveQueryKeys.summary(variables.meetingId),
-        response.data
-      )
+      queryClient.setQueryData(retrospectiveQueryKeys.summary(variables.meetingId), response.data)
     },
   })
 }

--- a/src/features/retrospectives/index.ts
+++ b/src/features/retrospectives/index.ts
@@ -1,2 +1,23 @@
 // Components
 export * from './components'
+
+// Hooks
+export * from './hooks'
+
+// API
+export { createSttJob, getSummary, publishSummary, updateSummary } from './retrospectives.api'
+
+// Types
+export type {
+  CreateSttJobParams,
+  KeyPoint,
+  KeyPointUpdateRequest,
+  PublishSummaryParams,
+  RetrospectiveSummaryResponse,
+  SttJobResponse,
+  SttJobStatus,
+  SummaryTopic,
+  UpdateSummaryParams,
+  UpdateSummaryRequest,
+  UpdateSummaryTopicRequest,
+} from './retrospectives.types'

--- a/src/features/retrospectives/retrospectives.api.ts
+++ b/src/features/retrospectives/retrospectives.api.ts
@@ -28,10 +28,7 @@ const STT_TIMEOUT = 5 * 60 * 1000
  * @param params - 생성 파라미터
  * @param signal - AbortSignal (취소 지원)
  */
-export const createSttJob = async (
-  params: CreateSttJobParams,
-  signal?: AbortSignal
-) => {
+export const createSttJob = async (params: CreateSttJobParams, signal?: AbortSignal) => {
   const { gatheringId, meetingId, file } = params
 
   const formData = new FormData()
@@ -56,12 +53,8 @@ export const createSttJob = async (
  *
  * @param meetingId - 약속 식별자
  */
-export const getSummary = async (
-  meetingId: number
-): Promise<RetrospectiveSummaryResponse> => {
-  return api.get<RetrospectiveSummaryResponse>(
-    RETROSPECTIVES_ENDPOINTS.SUMMARY(meetingId)
-  )
+export const getSummary = async (meetingId: number): Promise<RetrospectiveSummaryResponse> => {
+  return api.get<RetrospectiveSummaryResponse>(RETROSPECTIVES_ENDPOINTS.SUMMARY(meetingId))
 }
 
 /**

--- a/src/features/retrospectives/retrospectives.api.ts
+++ b/src/features/retrospectives/retrospectives.api.ts
@@ -3,8 +3,7 @@
  * @description 약속 회고 AI 요약 API 요청 함수
  */
 
-import { api, apiClient } from '@/api/client'
-import type { ApiResponse } from '@/api/types'
+import { api } from '@/api/client'
 
 import { RETROSPECTIVES_ENDPOINTS } from './retrospectives.endpoints'
 import type {
@@ -28,7 +27,10 @@ const STT_TIMEOUT = 5 * 60 * 1000
  * @param params - 생성 파라미터
  * @param signal - AbortSignal (취소 지원)
  */
-export const createSttJob = async (params: CreateSttJobParams, signal?: AbortSignal) => {
+export const createSttJob = async (
+  params: CreateSttJobParams,
+  signal?: AbortSignal
+): Promise<SttJobResponse> => {
   const { gatheringId, meetingId, file } = params
 
   const formData = new FormData()
@@ -36,7 +38,7 @@ export const createSttJob = async (params: CreateSttJobParams, signal?: AbortSig
     formData.append('file', file)
   }
 
-  const response = await apiClient.post<ApiResponse<SttJobResponse>>(
+  return api.post<SttJobResponse>(
     RETROSPECTIVES_ENDPOINTS.STT_JOBS(gatheringId, meetingId),
     formData,
     {
@@ -45,7 +47,6 @@ export const createSttJob = async (params: CreateSttJobParams, signal?: AbortSig
       signal,
     }
   )
-  return response.data
 }
 
 /**
@@ -62,13 +63,11 @@ export const getSummary = async (meetingId: number): Promise<RetrospectiveSummar
  *
  * @param params - 수정 파라미터 (meetingId + topics 데이터)
  */
-export const updateSummary = async (params: UpdateSummaryParams) => {
+export const updateSummary = async (
+  params: UpdateSummaryParams
+): Promise<RetrospectiveSummaryResponse> => {
   const { meetingId, data } = params
-  const response = await apiClient.patch<ApiResponse<RetrospectiveSummaryResponse>>(
-    RETROSPECTIVES_ENDPOINTS.SUMMARY(meetingId),
-    data
-  )
-  return response.data
+  return api.patch<RetrospectiveSummaryResponse>(RETROSPECTIVES_ENDPOINTS.SUMMARY(meetingId), data)
 }
 
 /**
@@ -76,9 +75,8 @@ export const updateSummary = async (params: UpdateSummaryParams) => {
  *
  * @param params - 발행 파라미터 (meetingId)
  */
-export const publishSummary = async (params: PublishSummaryParams) => {
-  const response = await apiClient.post<ApiResponse<RetrospectiveSummaryResponse>>(
-    RETROSPECTIVES_ENDPOINTS.PUBLISH(params.meetingId)
-  )
-  return response.data
+export const publishSummary = async (
+  params: PublishSummaryParams
+): Promise<RetrospectiveSummaryResponse> => {
+  return api.post<RetrospectiveSummaryResponse>(RETROSPECTIVES_ENDPOINTS.PUBLISH(params.meetingId))
 }

--- a/src/features/retrospectives/retrospectives.api.ts
+++ b/src/features/retrospectives/retrospectives.api.ts
@@ -1,0 +1,91 @@
+/**
+ * @file retrospectives.api.ts
+ * @description 약속 회고 AI 요약 API 요청 함수
+ */
+
+import { api, apiClient } from '@/api/client'
+import type { ApiResponse } from '@/api/types'
+
+import { RETROSPECTIVES_ENDPOINTS } from './retrospectives.endpoints'
+import type {
+  CreateSttJobParams,
+  PublishSummaryParams,
+  RetrospectiveSummaryResponse,
+  SttJobResponse,
+  UpdateSummaryParams,
+} from './retrospectives.types'
+
+/** STT 요청 타임아웃: 5분 (동기 API이므로 충분히 길게) */
+const STT_TIMEOUT = 5 * 60 * 1000
+
+/**
+ * STT Job 생성 (AI 요약 트리거)
+ *
+ * @description
+ * 녹음 파일을 업로드하거나 사전 의견만으로 STT + AI 요약을 실행합니다.
+ * 동기 API이므로 완료될 때까지 블로킹됩니다.
+ *
+ * @param params - 생성 파라미터
+ * @param signal - AbortSignal (취소 지원)
+ */
+export const createSttJob = async (
+  params: CreateSttJobParams,
+  signal?: AbortSignal
+) => {
+  const { gatheringId, meetingId, file } = params
+
+  const formData = new FormData()
+  if (file) {
+    formData.append('file', file)
+  }
+
+  const response = await apiClient.post<ApiResponse<SttJobResponse>>(
+    RETROSPECTIVES_ENDPOINTS.STT_JOBS(gatheringId, meetingId),
+    formData,
+    {
+      headers: { 'Content-Type': undefined },
+      timeout: STT_TIMEOUT,
+      signal,
+    }
+  )
+  return response.data
+}
+
+/**
+ * 회고 요약 조회
+ *
+ * @param meetingId - 약속 식별자
+ */
+export const getSummary = async (
+  meetingId: number
+): Promise<RetrospectiveSummaryResponse> => {
+  return api.get<RetrospectiveSummaryResponse>(
+    RETROSPECTIVES_ENDPOINTS.SUMMARY(meetingId)
+  )
+}
+
+/**
+ * 회고 요약 수정
+ *
+ * @param params - 수정 파라미터 (meetingId + topics 데이터)
+ */
+export const updateSummary = async (params: UpdateSummaryParams) => {
+  const { meetingId, data } = params
+  const response = await apiClient.patch<ApiResponse<RetrospectiveSummaryResponse>>(
+    RETROSPECTIVES_ENDPOINTS.SUMMARY(meetingId),
+    data
+  )
+  return response.data
+}
+
+/**
+ * 회고 요약 발행 (약속 회고 생성)
+ *
+ * @param params - 발행 파라미터 (meetingId)
+ */
+export const publishSummary = async (params: PublishSummaryParams) => {
+  const response = await apiClient.post<ApiResponse<RetrospectiveSummaryResponse>>(
+    RETROSPECTIVES_ENDPOINTS.PUBLISH(params.meetingId)
+  )
+  return response.data
+}

--- a/src/features/retrospectives/retrospectives.endpoints.ts
+++ b/src/features/retrospectives/retrospectives.endpoints.ts
@@ -1,0 +1,15 @@
+import { API_PATHS } from '@/api'
+
+export const RETROSPECTIVES_ENDPOINTS = {
+  /** STT Job 생성 (POST) */
+  STT_JOBS: (gatheringId: number, meetingId: number) =>
+    `${API_PATHS.GATHERINGS}/${gatheringId}/meetings/${meetingId}/stt/jobs`,
+
+  /** 회고 요약 조회/수정 (GET/PATCH) */
+  SUMMARY: (meetingId: number) =>
+    `${API_PATHS.MEETINGS}/${meetingId}/retrospectives/summary`,
+
+  /** 회고 요약 발행 (POST) */
+  PUBLISH: (meetingId: number) =>
+    `${API_PATHS.MEETINGS}/${meetingId}/retrospectives/summary/publish`,
+} as const

--- a/src/features/retrospectives/retrospectives.endpoints.ts
+++ b/src/features/retrospectives/retrospectives.endpoints.ts
@@ -6,8 +6,7 @@ export const RETROSPECTIVES_ENDPOINTS = {
     `${API_PATHS.GATHERINGS}/${gatheringId}/meetings/${meetingId}/stt/jobs`,
 
   /** 회고 요약 조회/수정 (GET/PATCH) */
-  SUMMARY: (meetingId: number) =>
-    `${API_PATHS.MEETINGS}/${meetingId}/retrospectives/summary`,
+  SUMMARY: (meetingId: number) => `${API_PATHS.MEETINGS}/${meetingId}/retrospectives/summary`,
 
   /** 회고 요약 발행 (POST) */
   PUBLISH: (meetingId: number) =>

--- a/src/features/retrospectives/retrospectives.types.ts
+++ b/src/features/retrospectives/retrospectives.types.ts
@@ -55,11 +55,8 @@ export interface RetrospectiveSummaryResponse {
 
 // ─── Request Types ───
 
-/** 주요 포인트 수정 요청 */
-export type KeyPointUpdateRequest = {
-  title: string
-  details: string[]
-}
+/** 주요 포인트 수정 요청 (KeyPoint와 동일 형태) */
+export type KeyPointUpdateRequest = KeyPoint
 
 /** 토픽 요약 수정 요청 */
 export type UpdateSummaryTopicRequest = {

--- a/src/features/retrospectives/retrospectives.types.ts
+++ b/src/features/retrospectives/retrospectives.types.ts
@@ -1,0 +1,87 @@
+/**
+ * @file retrospectives.types.ts
+ * @description 약속 회고 AI 요약 관련 타입 정의
+ */
+
+// ─── STT Job ───
+
+/** STT Job 상태 */
+export type SttJobStatus = 'PENDING' | 'PROCESSING' | 'DONE' | 'FAILED'
+
+/** STT Job 생성 요청 파라미터 */
+export type CreateSttJobParams = {
+  gatheringId: number
+  meetingId: number
+  file?: File
+}
+
+/** STT Job 응답 */
+export interface SttJobResponse {
+  jobId: number
+  meetingId: number
+  userId: number
+  status: SttJobStatus
+  summary: string | null
+  highlights: string[] | null
+  errorMessage: string | null
+  createdAt: string
+}
+
+// ─── Retrospective Summary ───
+
+/** 주요 포인트 항목 */
+export interface KeyPoint {
+  title: string
+  details: string[]
+}
+
+/** 토픽별 요약 */
+export interface SummaryTopic {
+  topicId: number
+  confirmOrder: number
+  topicTitle: string
+  topicDescription: string
+  summary: string
+  keyPoints: KeyPoint[]
+}
+
+/** 회고 요약 응답 (GET, PATCH, POST publish 공통) */
+export interface RetrospectiveSummaryResponse {
+  meetingId: number
+  isPublished: boolean
+  publishedAt: string | null
+  topics: SummaryTopic[]
+}
+
+// ─── Request Types ───
+
+/** 주요 포인트 수정 요청 */
+export type KeyPointUpdateRequest = {
+  title: string
+  details: string[]
+}
+
+/** 토픽 요약 수정 요청 */
+export type UpdateSummaryTopicRequest = {
+  topicId: number
+  summary: string
+  keyPoints: KeyPointUpdateRequest[]
+}
+
+/** 회고 요약 수정 요청 바디 */
+export type UpdateSummaryRequest = {
+  topics: UpdateSummaryTopicRequest[]
+}
+
+// ─── Hook Params ───
+
+/** 요약 수정 훅 파라미터 */
+export type UpdateSummaryParams = {
+  meetingId: number
+  data: UpdateSummaryRequest
+}
+
+/** 요약 발행 훅 파라미터 */
+export type PublishSummaryParams = {
+  meetingId: number
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

약속 회고 AI 요약 기능을 위한 API 레이어(타입, 엔드포인트, API 함수, React Query 훅)를 구현했습니다.
UI 작업(#93)에서 사용할 기반 코드입니다.

## 🔧 변경 사항

- STT Job, 요약 조회/수정/발행 타입 정의 (`retrospectives.types.ts`)
- 엔드포인트 상수 정의 (`retrospectives.endpoints.ts`)
- API 함수 구현: createSttJob(FormData + AbortSignal), getSummary, updateSummary, publishSummary (`retrospectives.api.ts`)
- React Query 훅 4종: useCreateSttJob(취소 지원), useSummary, useUpdateSummary, usePublishSummary
- 쿼리 키 팩토리 및 배럴 export 구성

## 📸 스크린샷 (선택 사항)

N/A

## 📄 기타

관련 이슈: #94
UI 작업 이슈: #93 (이 PR에 의존)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 회고 요약 생성(음성→텍스트 STT), 요약 조회, 수정 및 게시 기능을 앱에서 사용 가능
  * 요약 생성 요청 취소 지원 추가

* **Chores**
  * 회고 관련 API, 엔드포인트 및 타입 정의 추가
  * React Query 기반 훅으로 캐시 일관성 유지 및 간편한 사용성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->