### PR TITLE
[fix] 약속 상세 -> 사전의견 페이지 링크연동

### DIFF
--- a/src/features/topics/components/TopicHeader.tsx
+++ b/src/features/topics/components/TopicHeader.tsx
@@ -23,6 +23,8 @@ type ConfirmedHeaderProps = {
   confirmedTopic: boolean
   confirmedTopicDate: string | null
   progressStatus: MeetingProgressStatus
+  gatheringId: number
+  meetingId: number
 }
 
 type TopicHeaderProps = ProposedHeaderProps | ConfirmedHeaderProps
@@ -114,7 +116,11 @@ export default function TopicHeader(props: TopicHeaderProps) {
 
           <div className="flex gap-xsmall">
             {props.actions.canViewPreOpinions ? (
-              <Button variant="secondary" outline>
+              <Button
+                variant="secondary"
+                outline
+                onClick={() => navigate(ROUTES.PRE_OPINIONS(props.gatheringId, props.meetingId))}
+              >
                 사전 의견 확인하기
               </Button>
             ) : (
@@ -132,7 +138,14 @@ export default function TopicHeader(props: TopicHeaderProps) {
             )}
 
             {props.progressStatus !== 'POST' && (
-              <Button disabled={!props.actions.canWritePreOpinions}>사전 의견 작성하기</Button>
+              <Button
+                disabled={!props.actions.canWritePreOpinions}
+                onClick={() =>
+                  navigate(ROUTES.PRE_OPINION_WRITE(props.gatheringId, props.meetingId))
+                }
+              >
+                사전 의견 작성하기
+              </Button>
             )}
           </div>
         </div>

--- a/src/pages/Meetings/MeetingDetailPage.tsx
+++ b/src/pages/Meetings/MeetingDetailPage.tsx
@@ -219,6 +219,8 @@ export default function MeetingDetailPage() {
                       actions={confirmedTopicsInfiniteData.pages[0].actions}
                       confirmedTopicDate={meeting?.confirmedTopicDate ?? null}
                       progressStatus={meeting?.progressStatus ?? 'PRE'}
+                      gatheringId={gatheringId}
+                      meetingId={meetingId}
                     />
                     <ConfirmedTopicList
                       topics={confirmedTopicsInfiniteData.pages.flatMap(


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

약속 상세 페이지의 사전의견 작성 및 조회 버튼에 링크 연동 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 확정 탭에서 사전의견 관리 페이지로 이동할 수 있도록 개선
* 확정 탭에서 사전의견 작성 페이지로 바로 이동 가능 (작성 권한이 있을 때만 활성화)
* 페이지 이동 시 필요한 모임 및 회의 식별자 자동으로 전달

<!-- end of auto-generated comment: release notes by coderabbit.ai -->