### PR TITLE
feat: 내부 전용 테스트 로그인 페이지 구현 (#109)

### DIFF
--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -105,7 +105,8 @@ export const setupInterceptors = (): void => {
       // 401 응답은 세션이 만료되었거나 유효하지 않음을 의미합니다.
       if (error.response?.status === 401) {
         const currentPath = window.location.pathname
-        const isAlreadyOnLogin = currentPath === ROUTES.LOGIN
+        const isAlreadyOnLogin =
+          currentPath === ROUTES.LOGIN || currentPath === ROUTES.INTERNAL_LOGIN
         const isInvitePage = currentPath.startsWith(ROUTES.INVITE_BASE)
 
         const isLandingPage = currentPath === ROUTES.LANDING
@@ -115,7 +116,6 @@ export const setupInterceptors = (): void => {
           // React Query 캐시 전체 삭제 (인증 정보 포함)
           // 세션이 만료되었으므로 모든 캐시된 데이터는 더 이상 유효하지 않음
           queryClient.clear()
-          alert('로그인이 필요합니다. 로그인 페이지로 이동합니다.')
           window.location.href = ROUTES.LOGIN
         }
       }

--- a/src/features/auth/auth.api.ts
+++ b/src/features/auth/auth.api.ts
@@ -30,3 +30,11 @@ export const logout = async () => {
   const { data } = await apiClient.post<ApiResponse<null>>(AUTH_ENDPOINTS.LOGOUT)
   return data
 }
+
+export const internalLogin = async (loginId: string, password: string) => {
+  const { data } = await apiClient.post<ApiResponse<null>>(AUTH_ENDPOINTS.INTERNAL_LOGIN, {
+    loginId,
+    password,
+  })
+  return data
+}

--- a/src/features/auth/auth.endpoints.ts
+++ b/src/features/auth/auth.endpoints.ts
@@ -3,4 +3,5 @@ import { API_PATHS } from '@/api'
 export const AUTH_ENDPOINTS = {
   ME: `${API_PATHS.AUTH}/me`,
   LOGOUT: `${API_PATHS.AUTH}/logout`,
+  INTERNAL_LOGIN: `${API_PATHS.AUTH}/login`,
 } as const

--- a/src/pages/Auth/InternalLoginPage.tsx
+++ b/src/pages/Auth/InternalLoginPage.tsx
@@ -1,0 +1,66 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { type FormEvent, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { internalLogin } from '@/features/auth/auth.api'
+import { authQueryKeys } from '@/features/auth/hooks/authQueryKeys'
+import { ROUTES } from '@/shared/constants'
+import { Button } from '@/shared/ui/Button'
+import { Input } from '@/shared/ui/Input'
+
+export default function InternalLoginPage() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const [loginId, setLoginId] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setIsLoading(true)
+
+    try {
+      await internalLogin(loginId, password)
+      await queryClient.invalidateQueries({ queryKey: authQueryKeys.all })
+      navigate(ROUTES.HOME, { replace: true })
+    } catch {
+      setError('로그인에 실패했습니다. 아이디와 비밀번호를 확인해주세요.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex h-135 w-100 flex-col items-center justify-center gap-12 rounded-medium bg-white px-12 pb-12 pt-22 shadow-drop">
+      <div className="flex flex-col items-center gap-base">
+        <h1 className="typo-heading2 text-grey-800">INTERNAL LOGIN</h1>
+        <p className="typo-body2 text-grey-600">내부 전용 테스트 로그인</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex w-full flex-col gap-base">
+        <Input
+          label="아이디"
+          placeholder="아이디를 입력하세요"
+          value={loginId}
+          onChange={(e) => setLoginId(e.target.value)}
+        />
+        <Input
+          label="비밀번호"
+          type="password"
+          placeholder="비밀번호를 입력하세요"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+
+        {error && <p className="typo-body3 text-accent-300">{error}</p>}
+
+        <Button type="submit" size="large" disabled={!loginId || !password || isLoading}>
+          {isLoading ? '로그인 중...' : '로그인'}
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/src/pages/Auth/InternalLoginPage.tsx
+++ b/src/pages/Auth/InternalLoginPage.tsx
@@ -5,8 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import { internalLogin } from '@/features/auth/auth.api'
 import { authQueryKeys } from '@/features/auth/hooks/authQueryKeys'
 import { ROUTES } from '@/shared/constants'
-import { Button } from '@/shared/ui/Button'
-import { Input } from '@/shared/ui/Input'
+import { Button, Input } from '@/shared/ui'
 
 export default function InternalLoginPage() {
   const navigate = useNavigate()

--- a/src/pages/Auth/index.ts
+++ b/src/pages/Auth/index.ts
@@ -1,2 +1,3 @@
+export { default as InternalLoginPage } from './InternalLoginPage'
 export { default as LoginPage } from './LoginPage'
 export { default as OnboardingPage } from './OnboardingPage'

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,6 +10,7 @@ import {
   GatheringListPage,
   GatheringSettingPage,
   HomePage,
+  InternalLoginPage,
   InvitePage,
   LandingPage,
   LoginPage,
@@ -51,7 +52,12 @@ export const router = createBrowserRouter([
         children: [
           {
             element: <AuthLayout />,
-            children: [{ path: ROUTES.LOGIN, element: <LoginPage /> }],
+            children: [
+              { path: ROUTES.LOGIN, element: <LoginPage /> },
+              ...(import.meta.env.VITE_ENABLE_INTERNAL_LOGIN === 'true'
+                ? [{ path: ROUTES.INTERNAL_LOGIN, element: <InternalLoginPage /> }]
+                : []),
+            ],
           },
         ],
       },

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -1,6 +1,7 @@
 export const ROUTES = {
   // Auth
   LOGIN: '/login',
+  INTERNAL_LOGIN: '/internal-login',
   ONBOARDING: '/onboarding',
 
   HOME: '/',

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_APP_URL: string
   readonly VITE_KAKAO_MAP_KEY: string
   readonly VITE_USE_MOCK?: string
+  readonly VITE_ENABLE_INTERNAL_LOGIN?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

카카오 OAuth 외에 테스트 계정으로 로그인할 수 있는 내부 전용 로그인 페이지(`/internal-login`)를 구현했습니다.
환경 변수로 활성화 여부를 제어하여 운영 환경에서는 노출되지 않습니다.

## 🔧 변경 사항

- `InternalLoginPage` 페이지 컴포넌트 생성 (아이디/비밀번호 입력 폼)
- `POST /api/auth/login` 연동을 위한 `internalLogin` API 함수 추가
- 환경 변수 기반 조건부 라우트 등록 (PublicRoute > AuthLayout 하위)
- 401 인터셉터에서 내부 로그인 경로 예외 처리 및 불필요한 alert 제거

## 📸 스크린샷 (선택 사항)

<img width="613" height="693" alt="스크린샷 2026-03-29 오후 11 12 32" src="https://github.com/user-attachments/assets/e5379296-8c57-4a81-86f7-f28634fa69dc" />


## 📄 기타

- 개발서버에서의 필요 환경변수는 노션에 기입해놓았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 환경 플래그로 활성화 가능한 내부 로그인 페이지 및 관련 로그인 API 추가

* **개선 사항**
  * 401 처리 및 로그인 리다이렉트 흐름 개선 (불필요한 알림 제거)
  * 라우트 및 환경 변수 타입 추가로 내부 로그인 제어 가능하도록 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->