### PR TITLE
feat: 개발 서버 내부 로그인 페이지 기본 진입점 설정 (#113)

### DIFF
--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -106,7 +106,9 @@ export const setupInterceptors = (): void => {
       if (error.response?.status === 401) {
         const currentPath = window.location.pathname
         const isAlreadyOnLogin =
-          currentPath === ROUTES.LOGIN || currentPath === ROUTES.INTERNAL_LOGIN
+          currentPath === ROUTES.LOGIN ||
+          currentPath === ROUTES.INTERNAL_LOGIN ||
+          currentPath === ROUTES.KAKAO_LOGIN
         const isInvitePage = currentPath.startsWith(ROUTES.INVITE_BASE)
 
         const isLandingPage = currentPath === ROUTES.LANDING

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -105,8 +105,7 @@ export const setupInterceptors = (): void => {
       // 401 응답은 세션이 만료되었거나 유효하지 않음을 의미합니다.
       if (error.response?.status === 401) {
         const currentPath = window.location.pathname
-        const isAlreadyOnLogin =
-          currentPath === ROUTES.LOGIN || currentPath === ROUTES.KAKAO_LOGIN
+        const isAlreadyOnLogin = currentPath === ROUTES.LOGIN || currentPath === ROUTES.KAKAO_LOGIN
         const isInvitePage = currentPath.startsWith(ROUTES.INVITE_BASE)
 
         const isLandingPage = currentPath === ROUTES.LANDING

--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -106,9 +106,7 @@ export const setupInterceptors = (): void => {
       if (error.response?.status === 401) {
         const currentPath = window.location.pathname
         const isAlreadyOnLogin =
-          currentPath === ROUTES.LOGIN ||
-          currentPath === ROUTES.INTERNAL_LOGIN ||
-          currentPath === ROUTES.KAKAO_LOGIN
+          currentPath === ROUTES.LOGIN || currentPath === ROUTES.KAKAO_LOGIN
         const isInvitePage = currentPath.startsWith(ROUTES.INVITE_BASE)
 
         const isLandingPage = currentPath === ROUTES.LANDING

--- a/src/pages/Auth/InternalLoginPage.tsx
+++ b/src/pages/Auth/InternalLoginPage.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { type FormEvent, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 import { internalLogin } from '@/features/auth/auth.api'
 import { authQueryKeys } from '@/features/auth/hooks/authQueryKeys'
@@ -59,6 +59,9 @@ export default function InternalLoginPage() {
         <Button type="submit" size="large" disabled={!loginId || !password || isLoading}>
           {isLoading ? '로그인 중...' : '로그인'}
         </Button>
+        <Link to={ROUTES.KAKAO_LOGIN} className="typo-body3 text-center text-grey-500 hover:text-grey-700">
+          카카오 로그인
+        </Link>
       </form>
     </div>
   )

--- a/src/pages/Auth/InternalLoginPage.tsx
+++ b/src/pages/Auth/InternalLoginPage.tsx
@@ -59,7 +59,10 @@ export default function InternalLoginPage() {
         <Button type="submit" size="large" disabled={!loginId || !password || isLoading}>
           {isLoading ? '로그인 중...' : '로그인'}
         </Button>
-        <Link to={ROUTES.KAKAO_LOGIN} className="typo-body3 text-center text-grey-500 hover:text-grey-700">
+        <Link
+          to={ROUTES.KAKAO_LOGIN}
+          className="typo-body3 text-center text-grey-500 hover:text-grey-700"
+        >
           카카오 로그인
         </Link>
       </form>

--- a/src/pages/Auth/InternalLoginPage.tsx
+++ b/src/pages/Auth/InternalLoginPage.tsx
@@ -59,12 +59,14 @@ export default function InternalLoginPage() {
         <Button type="submit" size="large" disabled={!loginId || !password || isLoading}>
           {isLoading ? '로그인 중...' : '로그인'}
         </Button>
-        <Link
-          to={ROUTES.KAKAO_LOGIN}
-          className="typo-body3 text-center text-grey-500 hover:text-grey-700"
-        >
-          카카오 로그인
-        </Link>
+        {!isLoading && (
+          <Link
+            to={ROUTES.KAKAO_LOGIN}
+            className="typo-body3 text-center text-grey-500 hover:text-grey-700"
+          >
+            카카오 로그인
+          </Link>
+        )}
       </form>
     </div>
   )

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -52,12 +52,13 @@ export const router = createBrowserRouter([
         children: [
           {
             element: <AuthLayout />,
-            children: [
-              { path: ROUTES.LOGIN, element: <LoginPage /> },
-              ...(import.meta.env.VITE_ENABLE_INTERNAL_LOGIN === 'true'
-                ? [{ path: ROUTES.INTERNAL_LOGIN, element: <InternalLoginPage /> }]
-                : []),
-            ],
+            children:
+              import.meta.env.VITE_ENABLE_INTERNAL_LOGIN === 'true'
+                ? [
+                    { path: ROUTES.LOGIN, element: <InternalLoginPage /> },
+                    { path: ROUTES.KAKAO_LOGIN, element: <LoginPage /> },
+                  ]
+                : [{ path: ROUTES.LOGIN, element: <LoginPage /> }],
           },
         ],
       },

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -2,7 +2,6 @@ export const ROUTES = {
   // Auth
   LOGIN: '/login',
   KAKAO_LOGIN: '/login/kakao',
-  INTERNAL_LOGIN: '/internal-login',
   ONBOARDING: '/onboarding',
 
   HOME: '/',

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -1,6 +1,7 @@
 export const ROUTES = {
   // Auth
   LOGIN: '/login',
+  KAKAO_LOGIN: '/login/kakao',
   INTERNAL_LOGIN: '/internal-login',
   ONBOARDING: '/onboarding',
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

`VITE_ENABLE_INTERNAL_LOGIN=true` 환경에서 `/login` 경로에 내부 전용 로그인 페이지가 기본으로 노출되도록 변경했습니다.
기존 카카오 로그인은 `/login/kakao` 경로로 분리하여 내부 로그인 페이지 하단 링크로 접근할 수 있습니다.

## 🔧 변경 사항

- `KAKAO_LOGIN: '/login/kakao'` 경로 상수 추가
- `VITE_ENABLE_INTERNAL_LOGIN=true`일 때 `/login` → `InternalLoginPage`, `/login/kakao` → `LoginPage` 라우트 분기
- `InternalLoginPage` 하단에 `/login/kakao`로 이동하는 카카오 로그인 링크 추가
- 401 인터셉터 리다이렉트 스킵 조건에 `/login/kakao` 추가

## 📸 스크린샷 (선택 사항)

N/A

## 📄 기타

관련 이슈: #113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카카오 로그인 경로(/login/kakao) 추가로 카카오 계정 로그인이 가능해졌습니다.

* **UI 변경**
  * 내부 로그인 페이지에 “카카오 로그인” 링크가 추가되어 카카오 로그인으로 바로 이동할 수 있습니다.
  * 환경에 따라 기본 로그인 라우팅이 내부 로그인 또는 카카오 로그인으로 조정됩니다.

* **버그 수정/동작 개선**
  * 카카오 로그인 페이지에서 불필요한 강제 로그아웃 또는 리디렉션이 발생하지 않도록 안정성 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->