### PR TITLE
[fix] 1차 QA 관련 에러 수정

### DIFF
--- a/src/features/book/book.api.ts
+++ b/src/features/book/book.api.ts
@@ -71,19 +71,25 @@ export async function getBookDetail(bookId: number): Promise<BookDetail> {
  * 책 읽기 상태 토글 (READING ↔ COMPLETED)
  *
  * @param bookId - 토글할 책 ID
+ * @param personalBookId - 개인 책 ID
  * @returns 변경된 책 상세 정보
  *
  * @example
  * ```typescript
- * await toggleBookReadingStatus(1)
+ * await toggleBookReadingStatus(1, 42)
  * ```
  */
-export async function toggleBookReadingStatus(bookId: number): Promise<BookDetail> {
+export async function toggleBookReadingStatus(
+  bookId: number,
+  personalBookId: number
+): Promise<BookDetail> {
   if (USE_MOCK) {
     return getMockToggleBookReadingStatus(bookId)
   }
 
-  return api.post<BookDetail>(BOOK_ENDPOINTS.TOGGLE_READING(bookId))
+  return api.patch<BookDetail>(BOOK_ENDPOINTS.TOGGLE_READING(bookId), undefined, {
+    params: { personalBookId },
+  })
 }
 
 /**

--- a/src/features/book/book.api.ts
+++ b/src/features/book/book.api.ts
@@ -287,7 +287,7 @@ export async function updateBookRecord(
     return getMockUpdateBookRecord(personalBookId, recordId, body)
   }
 
-  return api.put<PersonalRecord>(BOOK_ENDPOINTS.RECORD_UPDATE(personalBookId, recordId), body)
+  return api.patch<PersonalRecord>(BOOK_ENDPOINTS.RECORD_UPDATE(personalBookId, recordId), body)
 }
 
 /**

--- a/src/features/book/book.endpoints.ts
+++ b/src/features/book/book.endpoints.ts
@@ -13,7 +13,7 @@ export const BOOK_ENDPOINTS = {
   // 책 삭제 (DELETE /api/book)
   DELETE: API_PATHS.BOOK,
 
-  // 책 읽기 상태 토글 (POST /api/book/{bookId}/isReading)
+  // 책 읽기 상태 토글 (PATCH /api/book/{bookId}/isReading)
   TOGGLE_READING: (bookId: number) => `${API_PATHS.BOOK}/${bookId}/isReading`,
 
   // 책 평가 조회 (GET /api/book/{bookId}/reviews/me)

--- a/src/features/book/book.mock.ts
+++ b/src/features/book/book.mock.ts
@@ -28,6 +28,7 @@ import type {
 
 const mockBookDetail: BookDetail = {
   bookId: 1,
+  personalBookId: 100,
   title: '물고기는 존재하지 않는다',
   publisher: '곰출판',
   authors: '룰루 밀러',

--- a/src/features/book/book.types.ts
+++ b/src/features/book/book.types.ts
@@ -17,6 +17,7 @@ export type BookSortOrder = 'DESC' | 'ASC'
 /** 책 상세 정보 */
 export interface BookDetail {
   bookId: number
+  personalBookId: number
   title: string
   publisher: string
   authors: string

--- a/src/features/book/book.types.ts
+++ b/src/features/book/book.types.ts
@@ -153,7 +153,7 @@ export interface PersonalRecord {
   recordId: number
   recordType: RecordType
   recordContent: string
-  meta: PersonalRecordMeta
+  meta: PersonalRecordMeta | null
   bookId: number
   createdAt: string
 }

--- a/src/features/book/components/BookLogList.tsx
+++ b/src/features/book/components/BookLogList.tsx
@@ -22,13 +22,13 @@ import { FilterDropdown } from '@/shared/ui/FilterDropdown'
 import { Tabs, TabsList, TabsTrigger } from '@/shared/ui/Tabs'
 
 type BookLogListProps = {
-  bookId: number
+  personalBookId: number
   isRecording: boolean
 }
 
 type OpenDropdown = 'gathering' | 'recordType' | null
 
-const BookLogList = ({ bookId, isRecording }: BookLogListProps) => {
+const BookLogList = ({ personalBookId, isRecording }: BookLogListProps) => {
   const isSticky = useScrollCollapse({ collapseThreshold: 500, expandThreshold: 100 })
   const [selectedGathering, setSelectedGathering] = useState('')
   const [recordType, setRecordType] = useState<RecordType | ''>('')
@@ -40,7 +40,7 @@ const BookLogList = ({ bookId, isRecording }: BookLogListProps) => {
 
   const navigate = useNavigate()
   const { deletePersonalRecord, deletePreOpinion, deleteRetrospective } =
-    useBookLogDeleteActions(bookId)
+    useBookLogDeleteActions(personalBookId)
 
   const {
     data: gatheringsData,
@@ -57,7 +57,7 @@ const BookLogList = ({ bookId, isRecording }: BookLogListProps) => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useBookRecords(bookId, {
+  } = useBookRecords(personalBookId, {
     gatheringId: selectedGathering ? Number(selectedGathering) : undefined,
     recordType: recordType || undefined,
     sort: sortType,
@@ -252,7 +252,7 @@ const BookLogList = ({ bookId, isRecording }: BookLogListProps) => {
       <PersonalRecordModal
         open={isModalOpen}
         onOpenChange={setIsModalOpen}
-        bookId={bookId}
+        personalBookId={personalBookId}
         mode={modalMode}
         record={editingRecord ?? undefined}
       />

--- a/src/features/book/components/PersonalRecordItem.tsx
+++ b/src/features/book/components/PersonalRecordItem.tsx
@@ -39,10 +39,10 @@ const PersonalRecordItem = ({ record, onEdit, onDelete }: PersonalRecordItemProp
 
       <div className="flex flex-col gap-medium">
         {/* 발췌 텍스트 + 페이지 번호 */}
-        {record.meta.excerpt && (
+        {record.meta?.excerpt && (
           <ExcerptBlock>
             <p className="typo-subtitle5 text-grey-800">{record.meta.excerpt}</p>
-            {record.meta.page && (
+            {record.meta?.page && (
               <span className="typo-body1 text-grey-600">
                 {record.meta.page}
                 {record.meta.page.endsWith('p') ? '' : 'p'}

--- a/src/features/book/components/PersonalRecordModal.tsx
+++ b/src/features/book/components/PersonalRecordModal.tsx
@@ -23,7 +23,7 @@ import { Textarea } from '@/shared/ui/Textarea'
 type PersonalRecordModalProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
-  bookId: number
+  personalBookId: number
   mode: 'create' | 'edit'
   record?: PersonalRecord
 }
@@ -45,16 +45,16 @@ const THOUGHT_MAX_LENGTH = 2000
  * @example
  * ```tsx
  * // 생성 모드
- * <PersonalRecordModal open={isOpen} onOpenChange={setIsOpen} bookId={1} mode="create" />
+ * <PersonalRecordModal open={isOpen} onOpenChange={setIsOpen} personalBookId={1} mode="create" />
  *
  * // 수정 모드
- * <PersonalRecordModal open={isOpen} onOpenChange={setIsOpen} bookId={1} mode="edit" record={record} />
+ * <PersonalRecordModal open={isOpen} onOpenChange={setIsOpen} personalBookId={1} mode="edit" record={record} />
  * ```
  */
 function PersonalRecordModal({
   open,
   onOpenChange,
-  bookId,
+  personalBookId,
   mode,
   record,
 }: PersonalRecordModalProps) {
@@ -73,8 +73,8 @@ function PersonalRecordModal({
         return {
           recordType: 'QUOTE' as RecordType,
           memoContent: '',
-          quoteContent: record.meta.excerpt || '',
-          pageNumber: record.meta.page || '',
+          quoteContent: record.meta?.excerpt || '',
+          pageNumber: record.meta?.page || '',
           thought: record.recordContent,
         }
       }
@@ -109,9 +109,9 @@ function PersonalRecordModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, mode, record])
 
-  const { mutate: createRecord, isPending: isCreating } = useCreateBookRecord(bookId)
+  const { mutate: createRecord, isPending: isCreating } = useCreateBookRecord(personalBookId)
   const { mutate: updateRecord, isPending: isUpdating } = useUpdateBookRecord(
-    bookId,
+    personalBookId,
     record?.recordId ?? 0
   )
   const resetForm = () => {

--- a/src/features/book/hooks/useBookDetail.ts
+++ b/src/features/book/hooks/useBookDetail.ts
@@ -43,18 +43,19 @@ export function useBookDetail(bookId: number) {
  * 책 읽기 상태를 토글하는 mutation 훅
  *
  * @param bookId - 토글할 책 ID
+ * @param personalBookId - 개인 책 ID
  *
  * @example
  * ```tsx
- * const { mutate: toggleStatus } = useToggleBookReadingStatus(bookId)
+ * const { mutate: toggleStatus } = useToggleBookReadingStatus(bookId, personalBookId)
  * <Switch onCheckedChange={() => toggleStatus()} />
  * ```
  */
-export function useToggleBookReadingStatus(bookId: number) {
+export function useToggleBookReadingStatus(bookId: number, personalBookId: number) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: () => toggleBookReadingStatus(bookId),
+    mutationFn: () => toggleBookReadingStatus(bookId, personalBookId),
     onMutate: async () => {
       await queryClient.cancelQueries({ queryKey: bookKeys.detail(bookId) })
 

--- a/src/features/book/hooks/useBookLogDeleteActions.ts
+++ b/src/features/book/hooks/useBookLogDeleteActions.ts
@@ -8,6 +8,7 @@ import { toast } from 'sonner'
 
 import { deleteMyPreOpinionAnswer } from '@/features/pre-opinion/preOpinion.api'
 import { deletePersonalRetrospective } from '@/features/retrospectives/personal/personalRetrospective.api'
+import { showToast } from '@/shared/lib/toast'
 
 import { deleteBookRecord } from '../book.api'
 import { bookRecordsKeys } from './useBookRecords'
@@ -37,7 +38,10 @@ export function useBookLogDeleteActions(bookId: number) {
 
   const { mutate: deletePersonalRecord } = useMutation({
     mutationFn: (recordId: number) => deleteBookRecord(bookId, recordId),
-    onSuccess: invalidateBookRecords,
+    onSuccess: () => {
+      invalidateBookRecords()
+      showToast('기록이 삭제되었어요.')
+    },
     onError: () => toast.error('기록 삭제에 실패했어요. 다시 시도해주세요.'),
   })
 

--- a/src/features/book/hooks/useCreateBookRecord.ts
+++ b/src/features/book/hooks/useCreateBookRecord.ts
@@ -5,6 +5,8 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
+import { showToast } from '@/shared/lib/toast'
+
 import { createBookRecord } from '../book.api'
 import type { CreateBookRecordBody } from '../book.types'
 import { bookRecordsKeys } from './useBookRecords'
@@ -27,6 +29,7 @@ export function useCreateBookRecord(personalBookId: number) {
     mutationFn: (body: CreateBookRecordBody) => createBookRecord(personalBookId, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: bookRecordsKeys.all })
+      showToast('기록이 저장되었어요.')
     },
   })
 }

--- a/src/features/book/hooks/useUpdateBookRecord.ts
+++ b/src/features/book/hooks/useUpdateBookRecord.ts
@@ -5,6 +5,8 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
+import { showToast } from '@/shared/lib/toast'
+
 import { updateBookRecord } from '../book.api'
 import type { UpdateBookRecordBody } from '../book.types'
 import { bookRecordsKeys } from './useBookRecords'
@@ -28,6 +30,7 @@ export function useUpdateBookRecord(personalBookId: number, recordId: number) {
     mutationFn: (body: UpdateBookRecordBody) => updateBookRecord(personalBookId, recordId, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: bookRecordsKeys.all })
+      showToast('수정이 완료되었어요.')
     },
   })
 }

--- a/src/features/pre-opinion/components/PreOpinionDetail.tsx
+++ b/src/features/pre-opinion/components/PreOpinionDetail.tsx
@@ -132,10 +132,10 @@ function PreOpinionDetail({ member, topics, gatheringId, meetingId }: PreOpinion
                     </h4>
                     <Badge>{topic.topicTypeLabel}</Badge>
                   </div>
-                  <p className="typo-body4 text-grey-600">{topic.description}</p>
+                  <p className="typo-body4 text-grey-600 whitespace-pre-line">{topic.description}</p>
                 </div>
                 {opinion.content && (
-                  <p className="typo-body1 text-black mt-base">{opinion.content}</p>
+                  <p className="typo-body1 text-black mt-base whitespace-pre-line">{opinion.content}</p>
                 )}
               </div>
             )

--- a/src/features/pre-opinion/components/PreOpinionDetail.tsx
+++ b/src/features/pre-opinion/components/PreOpinionDetail.tsx
@@ -1,16 +1,15 @@
 import { useNavigate } from 'react-router-dom'
 
 import { useAuth } from '@/features/auth'
-import { StarRate } from '@/shared/components/StarRate'
 import { ROUTES } from '@/shared/constants/routes'
 import { showToast } from '@/shared/lib/toast'
-import { Avatar, AvatarFallback, AvatarImage, Badge, TextButton } from '@/shared/ui'
-import { Chip } from '@/shared/ui/Chip'
+import { Avatar, AvatarFallback, AvatarImage, TextButton } from '@/shared/ui'
 import { useGlobalModalStore } from '@/store'
 
 import { useDeleteMyPreOpinionAnswer } from '../hooks/useDeleteMyPreOpinionAnswer'
 import { ROLE_TO_AVATAR_VARIANT } from '../preOpinion.constants'
 import type { PreOpinionAnswerTopic, PreOpinionMember } from '../preOpinion.types'
+import { PreOpinionReviewContent } from './PreOpinionReviewContent'
 
 type PreOpinionDetailProps = {
   member: PreOpinionMember
@@ -55,6 +54,13 @@ function PreOpinionDetail({ member, topics, gatheringId, meetingId }: PreOpinion
     })
   }
 
+  const bookKeywords = bookReview?.keywordInfo.filter((k) => k.type === 'BOOK') ?? []
+  const impressionKeywords = bookReview?.keywordInfo.filter((k) => k.type === 'IMPRESSION') ?? []
+  const topicsWithContent = topics.flatMap((topic) => {
+    const opinion = topicOpinions.find((o) => o.topicId === topic.topicId)
+    return opinion ? [{ ...topic, content: opinion.content }] : []
+  })
+
   return (
     <div className="flex flex-col gap-xlarge flex-1 mb-[100px]">
       {/* 회원 정보 섹션 */}
@@ -70,77 +76,14 @@ function PreOpinionDetail({ member, topics, gatheringId, meetingId }: PreOpinion
           {isMyOpinion && <TextButton onClick={() => handleDelete()}>내 의견 삭제하기</TextButton>}
         </div>
       )}
-      {/* 책 평가 섹션 */}
+      {/* 책 평가 + 주제별 의견 섹션 */}
       {bookReview && (
-        <section className="flex flex-col gap-small">
-          {/* 별점 */}
-          <div>
-            <p className="typo-body4 text-grey-600 mb-tiny">별점</p>
-            <div className="flex gap-small items-center">
-              <StarRate rating={bookReview.rating} size={36} />
-              <span className="typo-subtitle5 text-black">{bookReview.rating.toFixed(1)}</span>
-            </div>
-          </div>
-
-          {/* 책 키워드 */}
-          {bookReview.keywordInfo.filter((k) => k.type === 'BOOK').length > 0 && (
-            <div>
-              <p className="typo-body4 text-grey-600 mb-tiny">책 키워드</p>
-              <div className="flex gap-tiny flex-wrap">
-                {bookReview.keywordInfo
-                  .filter((k) => k.type === 'BOOK')
-                  .map((keyword) => (
-                    <Chip key={keyword.id} variant="success">
-                      {keyword.name}
-                    </Chip>
-                  ))}
-              </div>
-            </div>
-          )}
-
-          {/* 감상 키워드 */}
-          {bookReview.keywordInfo.filter((k) => k.type === 'IMPRESSION').length > 0 && (
-            <div>
-              <p className="typo-body4 text-grey-600 mb-tiny">감상 키워드</p>
-              <div className="flex gap-tiny flex-wrap">
-                {bookReview.keywordInfo
-                  .filter((k) => k.type === 'IMPRESSION')
-                  .map((keyword) => (
-                    <Chip key={keyword.id} className="bg-blue-100 text-blue-200">
-                      {keyword.name}
-                    </Chip>
-                  ))}
-              </div>
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* 주제별 의견 섹션 */}
-      {topicOpinions.length > 0 && (
-        <section className="flex flex-col gap-[32px]">
-          {topics.map((topic) => {
-            const opinion = topicOpinions.find((o) => o.topicId === topic.topicId)
-            if (!opinion) return null
-
-            return (
-              <div key={topic.topicId} className="flex flex-col">
-                <div className="flex flex-col gap-small">
-                  <div className="flex gap-xsmall items-center">
-                    <h4 className="typo-subtitle3 text-black">
-                      주제 {topic.confirmOrder}. {topic.title}
-                    </h4>
-                    <Badge>{topic.topicTypeLabel}</Badge>
-                  </div>
-                  <p className="typo-body4 text-grey-600 whitespace-pre-line">{topic.description}</p>
-                </div>
-                {opinion.content && (
-                  <p className="typo-body1 text-black mt-base whitespace-pre-line">{opinion.content}</p>
-                )}
-              </div>
-            )
-          })}
-        </section>
+        <PreOpinionReviewContent
+          rating={bookReview.rating}
+          bookKeywords={bookKeywords}
+          impressionKeywords={impressionKeywords}
+          topics={topicsWithContent}
+        />
       )}
     </div>
   )

--- a/src/features/pre-opinion/components/PreOpinionDetail.tsx
+++ b/src/features/pre-opinion/components/PreOpinionDetail.tsx
@@ -56,9 +56,9 @@ function PreOpinionDetail({ member, topics, gatheringId, meetingId }: PreOpinion
 
   const bookKeywords = bookReview?.keywordInfo.filter((k) => k.type === 'BOOK') ?? []
   const impressionKeywords = bookReview?.keywordInfo.filter((k) => k.type === 'IMPRESSION') ?? []
-  const topicsWithContent = topics.flatMap((topic) => {
+  const topicsWithContent = topics.map((topic) => {
     const opinion = topicOpinions.find((o) => o.topicId === topic.topicId)
-    return opinion ? [{ ...topic, content: opinion.content }] : []
+    return { ...topic, content: opinion?.content ?? null }
   })
 
   return (

--- a/src/features/pre-opinion/components/PreOpinionDetail.tsx
+++ b/src/features/pre-opinion/components/PreOpinionDetail.tsx
@@ -1,5 +1,9 @@
+import { useNavigate } from 'react-router-dom'
+
 import { useAuth } from '@/features/auth'
 import { StarRate } from '@/shared/components/StarRate'
+import { ROUTES } from '@/shared/constants/routes'
+import { showToast } from '@/shared/lib/toast'
 import { Avatar, AvatarFallback, AvatarImage, Badge, TextButton } from '@/shared/ui'
 import { Chip } from '@/shared/ui/Chip'
 import { useGlobalModalStore } from '@/store'
@@ -27,6 +31,7 @@ type PreOpinionDetailProps = {
  * ```
  */
 function PreOpinionDetail({ member, topics, gatheringId, meetingId }: PreOpinionDetailProps) {
+  const navigate = useNavigate()
   const { data: currentUser } = useAuth()
   const { openConfirm, openError } = useGlobalModalStore()
   const { bookReview, topicOpinions, memberInfo } = member
@@ -42,6 +47,10 @@ function PreOpinionDetail({ member, topics, gatheringId, meetingId }: PreOpinion
     if (!confirmed) return
 
     deleteMutation.mutate(undefined, {
+      onSuccess: () => {
+        showToast('사전의견 삭제가 완료되었어요.')
+        navigate(ROUTES.MEETING_DETAIL(gatheringId, meetingId))
+      },
       onError: (error) => openError('에러', error.userMessage),
     })
   }

--- a/src/features/pre-opinion/components/PreOpinionReviewContent.tsx
+++ b/src/features/pre-opinion/components/PreOpinionReviewContent.tsx
@@ -1,0 +1,116 @@
+import { StarRate } from '@/shared/components/StarRate'
+import { Badge } from '@/shared/ui'
+import { Chip } from '@/shared/ui/Chip'
+
+export type ReviewKeywordItem = {
+  id: number
+  name: string
+}
+
+export type ReviewTopicItem = {
+  topicId: number
+  title: string
+  description: string
+  topicTypeLabel: string
+  confirmOrder: number
+  content: string | null
+}
+
+type PreOpinionReviewContentProps = {
+  rating: number
+  bookKeywords: ReviewKeywordItem[]
+  impressionKeywords: ReviewKeywordItem[]
+  topics: ReviewTopicItem[]
+}
+
+/**
+ * 사전 의견 콘텐츠 (별점, 키워드, 주제별 의견)
+ *
+ * @description
+ * PreOpinionDetail과 PreOpinionSharePreviewModal에서 공통으로 사용하는
+ * 사전 의견 내용 표시 컴포넌트입니다.
+ *
+ * @example
+ * ```tsx
+ * <PreOpinionReviewContent
+ *   rating={4.5}
+ *   bookKeywords={[{ id: 1, name: '흥미로운' }]}
+ *   impressionKeywords={[{ id: 2, name: '감동적인' }]}
+ *   topics={topics}
+ * />
+ * ```
+ */
+function PreOpinionReviewContent({
+  rating,
+  bookKeywords,
+  impressionKeywords,
+  topics,
+}: PreOpinionReviewContentProps) {
+  return (
+    <div className="flex flex-col gap-xlarge">
+      {/* 책 평가 섹션 (별점 + 키워드) */}
+      <section className="flex flex-col gap-small">
+        {/* 별점 */}
+        <div>
+          <p className="typo-body4 text-grey-600 mb-tiny">별점</p>
+          <div className="flex gap-small items-center">
+            <StarRate rating={rating} size={36} />
+            <span className="typo-subtitle5 text-black">{rating.toFixed(1)}</span>
+          </div>
+        </div>
+
+        {/* 책 키워드 */}
+        {bookKeywords.length > 0 && (
+          <div>
+            <p className="typo-body4 text-grey-600 mb-tiny">책 키워드</p>
+            <div className="flex gap-tiny flex-wrap">
+              {bookKeywords.map((k) => (
+                <Chip key={k.id} variant="success">
+                  {k.name}
+                </Chip>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 감상 키워드 */}
+        {impressionKeywords.length > 0 && (
+          <div>
+            <p className="typo-body4 text-grey-600 mb-tiny">감상 키워드</p>
+            <div className="flex gap-tiny flex-wrap">
+              {impressionKeywords.map((k) => (
+                <Chip key={k.id} className="bg-blue-100 text-blue-200">
+                  {k.name}
+                </Chip>
+              ))}
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* 주제별 의견 섹션 */}
+      {topics.length > 0 && (
+        <section className="flex flex-col gap-[32px]">
+          {topics.map((topic) => (
+            <div key={topic.topicId} className="flex flex-col">
+              <div className="flex flex-col gap-small">
+                <div className="flex gap-xsmall items-center">
+                  <h4 className="typo-subtitle3 text-black">
+                    주제 {topic.confirmOrder}. {topic.title}
+                  </h4>
+                  <Badge>{topic.topicTypeLabel}</Badge>
+                </div>
+                <p className="typo-body4 text-grey-600 whitespace-pre-line">{topic.description}</p>
+              </div>
+              {topic.content && (
+                <p className="typo-body1 text-black mt-base whitespace-pre-line">{topic.content}</p>
+              )}
+            </div>
+          ))}
+        </section>
+      )}
+    </div>
+  )
+}
+
+export { PreOpinionReviewContent }

--- a/src/features/pre-opinion/components/PreOpinionSharePreviewModal.tsx
+++ b/src/features/pre-opinion/components/PreOpinionSharePreviewModal.tsx
@@ -1,0 +1,122 @@
+import { useKeywords } from '@/features/keywords'
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from '@/shared/ui'
+import { useGlobalModalStore } from '@/store'
+
+import { PreOpinionReviewContent, type ReviewTopicItem } from './PreOpinionReviewContent'
+
+export type SharePreviewTopic = ReviewTopicItem
+
+interface PreOpinionSharePreviewModalProps {
+  open: boolean
+  onClose: () => void
+  rating: number
+  keywordIds: number[]
+  topics: ReviewTopicItem[]
+  isSubmitting: boolean
+  onConfirmShare: () => Promise<void>
+  onGoToPreOpinions: () => void
+  onGoToBook: () => void
+}
+
+/**
+ * 사전 의견 공유 전 미리보기 모달
+ *
+ * @description
+ * 공유하기 버튼 클릭 시 작성한 내용을 한번 보여주고,
+ * 확인 후 실제 공유(제출)를 진행합니다.
+ * 공유 성공 시 전역 confirm 모달로 완료 안내를 표시합니다.
+ *
+ * @example
+ * ```tsx
+ * <PreOpinionSharePreviewModal
+ *   open={isOpen}
+ *   onClose={() => setIsOpen(false)}
+ *   rating={4.5}
+ *   keywordIds={[1, 2, 3]}
+ *   topics={topics}
+ *   isSubmitting={false}
+ *   onConfirmShare={handleShare}
+ *   onGoToPreOpinions={() => navigate(ROUTES.PRE_OPINIONS(gatheringId, meetingId))}
+ *   onGoToBook={() => navigate(ROUTES.BOOK_DETAIL(bookId))}
+ * />
+ * ```
+ */
+function PreOpinionSharePreviewModal({
+  open,
+  onClose,
+  rating,
+  keywordIds,
+  topics,
+  isSubmitting,
+  onConfirmShare,
+  onGoToPreOpinions,
+  onGoToBook,
+}: PreOpinionSharePreviewModalProps) {
+  const { openConfirm } = useGlobalModalStore()
+  const { data: keywordsData } = useKeywords()
+
+  const bookKeywords =
+    keywordsData?.keywords.filter(
+      (k) => k.type === 'BOOK' && k.isSelectable && keywordIds.includes(k.id)
+    ) ?? []
+
+  const impressionKeywords =
+    keywordsData?.keywords.filter(
+      (k) => k.type === 'IMPRESSION' && k.isSelectable && keywordIds.includes(k.id)
+    ) ?? []
+
+  const handleShare = async () => {
+    try {
+      await onConfirmShare()
+      onClose()
+      const confirmed = await openConfirm(
+        '사전 의견이 공유됐어요',
+        '내 책장 기록에도 함께 반영됐어요',
+        { confirmText: '확인', cancelText: '내 책장 보기' }
+      )
+      if (confirmed) {
+        onGoToPreOpinions()
+      } else {
+        onGoToBook()
+      }
+    } catch {
+      // 오류는 페이지에서 openError로 처리됨
+    }
+  }
+
+  return (
+    <Modal open={open} onOpenChange={(open) => !open && onClose()}>
+      <ModalContent variant="wide">
+        <ModalHeader>
+          <ModalTitle>사전 의견 공유하기</ModalTitle>
+          <p className="typo-body2 text-grey-600 mt-xtiny">
+            이 내용으로 공유할까요? 사전 의견을 공유하면 수정할 수 없어요.
+          </p>
+        </ModalHeader>
+        <ModalBody>
+          <PreOpinionReviewContent
+            rating={rating}
+            bookKeywords={bookKeywords}
+            impressionKeywords={impressionKeywords}
+            topics={topics}
+          />
+        </ModalBody>
+        <ModalFooter variant="full">
+          <Button className="w-full" onClick={handleShare} disabled={isSubmitting}>
+            {isSubmitting ? '공유 중...' : '공유하기'}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default PreOpinionSharePreviewModal

--- a/src/features/pre-opinion/components/PreOpinionSharePreviewModal.tsx
+++ b/src/features/pre-opinion/components/PreOpinionSharePreviewModal.tsx
@@ -20,7 +20,7 @@ interface PreOpinionSharePreviewModalProps {
   rating: number
   keywordIds: number[]
   topics: ReviewTopicItem[]
-  isSubmitting: boolean
+  isPending: boolean
   onConfirmShare: () => Promise<void>
   onGoToPreOpinions: () => void
   onGoToBook: () => void
@@ -42,7 +42,7 @@ interface PreOpinionSharePreviewModalProps {
  *   rating={4.5}
  *   keywordIds={[1, 2, 3]}
  *   topics={topics}
- *   isSubmitting={false}
+ *   isPending={false}
  *   onConfirmShare={handleShare}
  *   onGoToPreOpinions={() => navigate(ROUTES.PRE_OPINIONS(gatheringId, meetingId))}
  *   onGoToBook={() => navigate(ROUTES.BOOK_DETAIL(bookId))}
@@ -55,7 +55,7 @@ function PreOpinionSharePreviewModal({
   rating,
   keywordIds,
   topics,
-  isSubmitting,
+  isPending,
   onConfirmShare,
   onGoToPreOpinions,
   onGoToBook,
@@ -110,8 +110,8 @@ function PreOpinionSharePreviewModal({
           />
         </ModalBody>
         <ModalFooter variant="full">
-          <Button className="w-full" onClick={handleShare} disabled={isSubmitting}>
-            {isSubmitting ? '공유 중...' : '공유하기'}
+          <Button className="w-full" onClick={handleShare} disabled={isPending}>
+            {isPending ? '공유 중...' : '공유하기'}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/src/features/pre-opinion/components/PreOpinionSharePreviewModal.tsx
+++ b/src/features/pre-opinion/components/PreOpinionSharePreviewModal.tsx
@@ -60,7 +60,7 @@ function PreOpinionSharePreviewModal({
   onGoToPreOpinions,
   onGoToBook,
 }: PreOpinionSharePreviewModalProps) {
-  const { openConfirm } = useGlobalModalStore()
+  const { openAlert } = useGlobalModalStore()
   const { data: keywordsData } = useKeywords()
 
   const bookKeywords =
@@ -77,16 +77,9 @@ function PreOpinionSharePreviewModal({
     try {
       await onConfirmShare()
       onClose()
-      const confirmed = await openConfirm(
-        '사전 의견이 공유됐어요',
-        '내 책장 기록에도 함께 반영됐어요',
-        { confirmText: '확인', cancelText: '내 책장 보기' }
-      )
-      if (confirmed) {
-        onGoToPreOpinions()
-      } else {
-        onGoToBook()
-      }
+      openAlert('사전 의견이 공유됐어요', '내 책장 기록에도 함께 반영됐어요', onGoToPreOpinions, {
+        secondaryAction: { text: '내 책장 보기', onClick: onGoToBook },
+      })
     } catch {
       // 오류는 페이지에서 openError로 처리됨
     }

--- a/src/features/pre-opinion/components/PreOpinionWriteHeader.tsx
+++ b/src/features/pre-opinion/components/PreOpinionWriteHeader.tsx
@@ -69,7 +69,7 @@ const PreOpinionWriteHeader = ({
               onClick={onSave}
               disabled={isSaving || !isReviewValid}
             >
-              {isSaving ? '저장 중...' : '저장하기'}
+              {isSaving ? '저장 중...' : '임시저장'}
             </Button>
             <Button onClick={onSubmit} disabled={isSubmitting || isSaving || !isReviewValid}>
               {isSubmitting ? '공유 중...' : '공유하기'}

--- a/src/features/pre-opinion/components/TopicItem.tsx
+++ b/src/features/pre-opinion/components/TopicItem.tsx
@@ -27,7 +27,7 @@ function TopicItem({ topic, onChange }: TopicItemProps) {
       </Container.Title>
       <Container.Content>
         <div className="flex flex-col gap-small">
-          <p className="typo-body4 text-grey-600">{topic.topicDescription}</p>
+          <p className="typo-body4 text-grey-600 whitespace-pre-line">{topic.topicDescription}</p>
           <Textarea
             placeholder="자유롭게 작성해주세요"
             value={value}

--- a/src/features/pre-opinion/components/index.ts
+++ b/src/features/pre-opinion/components/index.ts
@@ -1,5 +1,6 @@
 export * from './BookReviewSection'
 export * from './PreOpinionDetail'
 export * from './PreOpinionMemberList'
+export * from './PreOpinionReviewContent'
 export * from './PreOpinionWriteHeader'
 export * from './TopicItem'

--- a/src/features/pre-opinion/preOpinion.endpoints.ts
+++ b/src/features/pre-opinion/preOpinion.endpoints.ts
@@ -5,9 +5,9 @@ export const PRE_OPINION_ENDPOINTS = {
   ANSWERS: (gatheringId: number, meetingId: number) =>
     `${API_PATHS.GATHERINGS}/${gatheringId}/meetings/${meetingId}/answers`,
 
-  // 내 사전 의견 삭제 (DELETE /api/gatherings/{gatheringId}/meetings/{meetingId}/topics/answers/me)
+  // 내 사전 의견 삭제 (DELETE /api/gatherings/{gatheringId}/meetings/{meetingId}/answers/me)
   DELETE_MY_ANSWER: (gatheringId: number, meetingId: number) =>
-    `${API_PATHS.GATHERINGS}/${gatheringId}/meetings/${meetingId}/topics/answers/me`,
+    `${API_PATHS.GATHERINGS}/${gatheringId}/meetings/${meetingId}/answers/me`,
   // 사전 의견 조회 (GET /api/gatherings/{gatheringId}/meetings/{meetingId}/answers/me)
   DETAIL: (gatheringId: number, meetingId: number) =>
     `${API_PATHS.GATHERINGS}/${gatheringId}/meetings/${meetingId}/answers/me`,

--- a/src/features/retrospectives/personal/hooks/usePersonalRetrospective.ts
+++ b/src/features/retrospectives/personal/hooks/usePersonalRetrospective.ts
@@ -34,9 +34,8 @@ export const usePersonalRetrospective = (
   params: GetPersonalRetrospectiveParams,
   enabled = true
 ) => {
-  const { gatheringId, meetingId } = params
-  const isValidParams =
-    !Number.isNaN(gatheringId) && gatheringId > 0 && !Number.isNaN(meetingId) && meetingId > 0
+  const { meetingId } = params
+  const isValidParams = !Number.isNaN(meetingId) && meetingId > 0
 
   return useQuery<GetPersonalRetrospectiveResponse, ApiError>({
     queryKey: personalRetrospectiveQueryKeys.detail(params),

--- a/src/features/retrospectives/personal/personalRetrospective.api.ts
+++ b/src/features/retrospectives/personal/personalRetrospective.api.ts
@@ -35,7 +35,6 @@ const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true'
  * @returns 개인 회고 응답 데이터
  */
 export const getPersonalRetrospective = async ({
-  gatheringId,
   meetingId,
 }: GetPersonalRetrospectiveParams): Promise<GetPersonalRetrospectiveResponse> => {
   if (USE_MOCK) {
@@ -44,7 +43,7 @@ export const getPersonalRetrospective = async ({
   }
 
   const data = await api.get<GetPersonalRetrospectiveResponse>(
-    PERSONAL_RETROSPECTIVE_ENDPOINTS.DETAIL(gatheringId, meetingId)
+    PERSONAL_RETROSPECTIVE_ENDPOINTS.FORM(meetingId)
   )
 
   return {

--- a/src/features/retrospectives/personal/personalRetrospective.endpoints.ts
+++ b/src/features/retrospectives/personal/personalRetrospective.endpoints.ts
@@ -2,8 +2,7 @@ import { API_PATHS } from '@/api'
 
 export const PERSONAL_RETROSPECTIVE_ENDPOINTS = {
   // 개인 회고 입력 폼 조회 (GET /api/meetings/{meetingId}/retrospectives/personal/form)
-  FORM: (meetingId: number) =>
-    `${API_PATHS.MEETINGS}/${meetingId}/retrospectives/personal/form`,
+  FORM: (meetingId: number) => `${API_PATHS.MEETINGS}/${meetingId}/retrospectives/personal/form`,
   // 개인 회고 저장 (POST /api/meetings/{meetingId}/retrospectives/personal)
   SAVE: (meetingId: number) => `${API_PATHS.MEETINGS}/${meetingId}/retrospectives/personal`,
   // 개인 회고 뷰 조회 (GET /api/meetings/{meetingId}/retrospectives/personal)

--- a/src/features/retrospectives/personal/personalRetrospective.endpoints.ts
+++ b/src/features/retrospectives/personal/personalRetrospective.endpoints.ts
@@ -1,9 +1,9 @@
 import { API_PATHS } from '@/api'
 
 export const PERSONAL_RETROSPECTIVE_ENDPOINTS = {
-  // 개인 회고 조회 (GET /api/gatherings/{gatheringId}/meetings/{meetingId}/retrospective/personal)
-  DETAIL: (gatheringId: number, meetingId: number) =>
-    `${API_PATHS.GATHERINGS}/${gatheringId}/meetings/${meetingId}/retrospective/personal`,
+  // 개인 회고 입력 폼 조회 (GET /api/meetings/{meetingId}/retrospectives/personal/form)
+  FORM: (meetingId: number) =>
+    `${API_PATHS.MEETINGS}/${meetingId}/retrospectives/personal/form`,
   // 개인 회고 저장 (POST /api/meetings/{meetingId}/retrospectives/personal)
   SAVE: (meetingId: number) => `${API_PATHS.MEETINGS}/${meetingId}/retrospectives/personal`,
   // 개인 회고 뷰 조회 (GET /api/meetings/{meetingId}/retrospectives/personal)

--- a/src/features/retrospectives/personal/personalRetrospective.types.ts
+++ b/src/features/retrospectives/personal/personalRetrospective.types.ts
@@ -40,11 +40,9 @@ export type PersonalRetrospectiveMember = {
 }
 
 /**
- * 개인 회고 조회 요청 파라미터
+ * 개인 회고 입력 폼 조회 요청 파라미터
  */
 export type GetPersonalRetrospectiveParams = {
-  /** 모임 ID */
-  gatheringId: number
   /** 약속 ID */
   meetingId: number
 }

--- a/src/pages/Books/BookDetailPage.tsx
+++ b/src/pages/Books/BookDetailPage.tsx
@@ -12,7 +12,10 @@ export default function BookDetailPage() {
   const bookId = Number(id)
 
   const { data: bookDetail } = useBookDetail(bookId)
-  const { mutate: toggleReadingStatus } = useToggleBookReadingStatus(bookId)
+  const { mutate: toggleReadingStatus } = useToggleBookReadingStatus(
+    bookId,
+    bookDetail?.personalBookId ?? 0
+  )
 
   const isRecording = bookDetail?.bookReadingStatus === 'READING'
   const isBookLogSticky = useScrollCollapse({ collapseThreshold: 500, expandThreshold: 100 })

--- a/src/pages/Books/BookDetailPage.tsx
+++ b/src/pages/Books/BookDetailPage.tsx
@@ -30,7 +30,7 @@ export default function BookDetailPage() {
           onToggleRecording={() => toggleReadingStatus()}
         />
       </div>
-      <BookLogList bookId={bookId} isRecording={isRecording} />
+      <BookLogList personalBookId={bookDetail?.personalBookId ?? 0} isRecording={isRecording} />
     </>
   )
 }

--- a/src/pages/Home/components/HomeMeetingCard.tsx
+++ b/src/pages/Home/components/HomeMeetingCard.tsx
@@ -58,7 +58,7 @@ export default function HomeMeetingCard({ meeting }: HomeMeetingCardProps) {
   const handleActionClick = (e: MouseEvent) => {
     e.stopPropagation()
     if (isUpcoming && preOpinionTemplateConfirmed) {
-      navigate(ROUTES.PRE_OPINIONS(gatheringId, meetingId))
+      navigate(ROUTES.PRE_OPINION_WRITE(gatheringId, meetingId))
     }
     // TODO: 종료 → 개인 회고 작성 페이지 연결
   }

--- a/src/pages/Home/components/ReadingBooksSection.tsx
+++ b/src/pages/Home/components/ReadingBooksSection.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 
-import { BookCarousel, useBooks } from '@/features/book'
+import type { SearchBookItem } from '@/features/book'
+import { BookCarousel, BookSearchModal, useBooks, useCreateBook } from '@/features/book'
 import { ROUTES } from '@/shared/constants'
 import { useDeferredLoading } from '@/shared/hooks'
+import { showToast } from '@/shared/lib/toast'
 import { Button, Tabs, TabsList, TabsTrigger } from '@/shared/ui'
+import { useGlobalModalStore } from '@/store'
 
 import HomeBookCard from './HomeBookCard'
 import HomeSectionHeader from './HomeSectionHeader'
@@ -14,7 +16,9 @@ type BookTab = 'all' | 'pre' | 'post'
 export default function ReadingBooksSection() {
   // TODO: pre/post 탭 활성화 시 activeTab을 useBooks filter 파라미터로 연결 필요
   const [activeTab, setActiveTab] = useState<BookTab>('all')
-  const navigate = useNavigate()
+  const [isSearchModalOpen, setIsSearchModalOpen] = useState(false)
+  const { mutateAsync: createBook, isPending: isCreating } = useCreateBook()
+  const { openConfirm } = useGlobalModalStore()
 
   const { data, isLoading } = useBooks({ readingStatus: 'READING' })
   const showSkeleton = useDeferredLoading(isLoading)
@@ -64,12 +68,7 @@ export default function ReadingBooksSection() {
               첫 번째 책을 등록하고 독서 기록을 시작해 보세요!
             </p>
           </div>
-          <Button
-            variant="secondary"
-            outline
-            size="small"
-            onClick={() => navigate(ROUTES.BOOK_SEARCH)}
-          >
+          <Button variant="secondary" outline size="small" onClick={() => setIsSearchModalOpen(true)}>
             책 추가하기
           </Button>
         </div>
@@ -86,6 +85,28 @@ export default function ReadingBooksSection() {
           ))}
         </BookCarousel>
       )}
+
+      <BookSearchModal
+        open={isSearchModalOpen}
+        onOpenChange={setIsSearchModalOpen}
+        onSelectBook={async (book: SearchBookItem) => {
+          try {
+            await createBook({
+              title: book.title,
+              authors: book.authors.join(', '),
+              publisher: book.publisher,
+              isbn: book.isbn,
+              thumbnail: book.thumbnail,
+            })
+            showToast('책이 추가되었습니다.')
+          } catch {
+            openConfirm('등록 실패', '책 등록에 실패했습니다.\n잠시 후 다시 시도해주세요.', {
+              confirmText: '확인',
+            })
+          }
+        }}
+        isPending={isCreating}
+      />
     </section>
   )
 }

--- a/src/pages/Home/components/ReadingBooksSection.tsx
+++ b/src/pages/Home/components/ReadingBooksSection.tsx
@@ -68,7 +68,12 @@ export default function ReadingBooksSection() {
               첫 번째 책을 등록하고 독서 기록을 시작해 보세요!
             </p>
           </div>
-          <Button variant="secondary" outline size="small" onClick={() => setIsSearchModalOpen(true)}>
+          <Button
+            variant="secondary"
+            outline
+            size="small"
+            onClick={() => setIsSearchModalOpen(true)}
+          >
             책 추가하기
           </Button>
         </div>

--- a/src/pages/PreOpinions/PreOpinionWritePage.tsx
+++ b/src/pages/PreOpinions/PreOpinionWritePage.tsx
@@ -39,7 +39,15 @@ export default function PreOpinionWritePage() {
   })
 
   const reviewRef = useRef<BookReviewFormValues>({ rating: 0, keywordIds: [], isValid: false })
-  const [formReviewValid, setFormReviewValid] = useState<boolean | null>(null)
+  const [reviewValidFor, setReviewValidFor] = useState<{
+    gatheringId: number
+    meetingId: number
+    isValid: boolean
+  } | null>(null)
+  const formReviewValid =
+    reviewValidFor?.gatheringId === numGatheringId && reviewValidFor?.meetingId === numMeetingId
+      ? reviewValidFor.isValid
+      : null
   const isReviewValid = formReviewValid ?? !!preOpinion?.review
   const answersRef = useRef<Map<number, string>>(new Map())
 
@@ -49,6 +57,11 @@ export default function PreOpinionWritePage() {
     keywordIds: number[]
     topics: SharePreviewTopic[]
   } | null>(null)
+
+  useEffect(() => {
+    reviewRef.current = { rating: 0, keywordIds: [], isValid: false }
+    answersRef.current = new Map()
+  }, [numGatheringId, numMeetingId])
 
   useEffect(() => {
     if (!preOpinion?.review) return
@@ -84,10 +97,17 @@ export default function PreOpinionWritePage() {
     meetingId: numMeetingId,
   })
 
-  const handleReviewChange = useCallback((values: BookReviewFormValues) => {
-    reviewRef.current = values
-    setFormReviewValid(values.isValid)
-  }, [])
+  const handleReviewChange = useCallback(
+    (values: BookReviewFormValues) => {
+      reviewRef.current = values
+      setReviewValidFor({
+        gatheringId: numGatheringId,
+        meetingId: numMeetingId,
+        isValid: values.isValid,
+      })
+    },
+    [numGatheringId, numMeetingId]
+  )
 
   const handleTopicChange = useCallback((topicId: number, content: string) => {
     answersRef.current.set(topicId, content)

--- a/src/pages/PreOpinions/PreOpinionWritePage.tsx
+++ b/src/pages/PreOpinions/PreOpinionWritePage.tsx
@@ -147,9 +147,7 @@ export default function PreOpinionWritePage() {
       topicTypeLabel: t.topicTypeLabel,
       confirmOrder: t.confirmOrder,
       content: normalizeAnswer(
-        answersRef.current.has(t.topicId)
-          ? answersRef.current.get(t.topicId)!
-          : (t.content ?? ''),
+        answersRef.current.has(t.topicId) ? answersRef.current.get(t.topicId)! : (t.content ?? '')
       ),
     }))
 

--- a/src/pages/PreOpinions/PreOpinionWritePage.tsx
+++ b/src/pages/PreOpinions/PreOpinionWritePage.tsx
@@ -3,10 +3,14 @@ import { useNavigate, useParams } from 'react-router-dom'
 
 import type { BookReviewFormValues } from '@/features/book/components/BookReviewForm'
 import BookReviewSection from '@/features/pre-opinion/components/BookReviewSection'
+import PreOpinionSharePreviewModal, {
+  type SharePreviewTopic,
+} from '@/features/pre-opinion/components/PreOpinionSharePreviewModal'
 import PreOpinionWriteHeader from '@/features/pre-opinion/components/PreOpinionWriteHeader'
 import TopicItem from '@/features/pre-opinion/components/TopicItem'
 import { usePreOpinion, useSavePreOpinion, useSubmitPreOpinion } from '@/features/pre-opinion/hooks'
 import SubPageHeader from '@/shared/components/SubPageHeader'
+import { ROUTES } from '@/shared/constants/routes'
 import { Card, Spinner } from '@/shared/ui'
 import { useGlobalModalStore } from '@/store'
 
@@ -33,6 +37,13 @@ export default function PreOpinionWritePage() {
   const [formReviewValid, setFormReviewValid] = useState<boolean | null>(null)
   const isReviewValid = formReviewValid ?? !!preOpinion?.review
   const answersRef = useRef<Map<number, string>>(new Map())
+
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false)
+  const [previewSnapshot, setPreviewSnapshot] = useState<{
+    rating: number
+    keywordIds: number[]
+    topics: SharePreviewTopic[]
+  } | null>(null)
 
   useEffect(() => {
     if (!preOpinion?.review) return
@@ -122,7 +133,29 @@ export default function PreOpinionWritePage() {
     })
   }, [buildSaveBody, save, openError])
 
-  const handleSubmit = useCallback(async () => {
+  const handleOpenPreview = useCallback(() => {
+    if (!preOpinion) return
+
+    const topics: SharePreviewTopic[] = preOpinion.preOpinion.topics.map((t) => ({
+      topicId: t.topicId,
+      title: t.topicTitle,
+      description: t.topicDescription,
+      topicTypeLabel: t.topicTypeLabel,
+      confirmOrder: t.confirmOrder,
+      content: answersRef.current.has(t.topicId)
+        ? answersRef.current.get(t.topicId)!
+        : (t.content ?? null),
+    }))
+
+    setPreviewSnapshot({
+      rating: reviewRef.current.rating,
+      keywordIds: reviewRef.current.keywordIds,
+      topics,
+    })
+    setIsPreviewOpen(true)
+  }, [preOpinion])
+
+  const handleConfirmShare = useCallback(async () => {
     const saveBody = buildSaveBody()
     if (!saveBody) return
     const submitBody = buildSubmitBody()
@@ -132,14 +165,13 @@ export default function PreOpinionWritePage() {
       await saveAsync(saveBody)
     } catch {
       openError('오류', '사전 의견 저장 중 오류가 발생했습니다.')
-      return
+      throw new Error('save failed')
     }
 
-    try {
-      await submitAsync(submitBody)
-    } catch {
+    await submitAsync(submitBody).catch(() => {
       openError('오류', '사전 의견 제출 중 오류가 발생했습니다.')
-    }
+      throw new Error('submit failed')
+    })
   }, [buildSaveBody, buildSubmitBody, saveAsync, submitAsync, openError])
 
   if (isLoading || !preOpinion) {
@@ -160,15 +192,15 @@ export default function PreOpinionWritePage() {
         book={preOpinion.book}
         updatedAt={preOpinion.preOpinion.updatedAt}
         onSave={handleSave}
-        onSubmit={handleSubmit}
+        onSubmit={handleOpenPreview}
         isSaving={isSaving}
         isSubmitting={isSubmitting}
         isReviewValid={isReviewValid}
       />
 
       <div className="bg-grey-100">
-        <section className="max-w-[1200px] mx-auto py-large flex flex-col gap-base">
-          <Card className="border-primary-200 bg-primary-100 text-primary-400 px-small py-[10px] rounded-small">
+        <section className="max-w-300 mx-auto py-large flex flex-col gap-base">
+          <Card className="border-primary-200 bg-primary-100 text-primary-400 px-small py-2.5 rounded-small">
             <p className="typo-caption1">
               작성하신 사전 의견은 약속 당일이 되면 멤버들에게 자동으로 공개돼요.
             </p>
@@ -179,6 +211,20 @@ export default function PreOpinionWritePage() {
           ))}
         </section>
       </div>
+
+      {previewSnapshot && (
+        <PreOpinionSharePreviewModal
+          open={isPreviewOpen}
+          onClose={() => setIsPreviewOpen(false)}
+          rating={previewSnapshot.rating}
+          keywordIds={previewSnapshot.keywordIds}
+          topics={previewSnapshot.topics}
+          isSubmitting={isSubmitting}
+          onConfirmShare={handleConfirmShare}
+          onGoToPreOpinions={() => navigate(ROUTES.PRE_OPINIONS(numGatheringId, numMeetingId))}
+          onGoToBook={() => navigate(ROUTES.BOOK_DETAIL(preOpinion.book.bookId))}
+        />
+      )}
     </>
   )
 }

--- a/src/pages/PreOpinions/PreOpinionWritePage.tsx
+++ b/src/pages/PreOpinions/PreOpinionWritePage.tsx
@@ -219,7 +219,7 @@ export default function PreOpinionWritePage() {
           rating={previewSnapshot.rating}
           keywordIds={previewSnapshot.keywordIds}
           topics={previewSnapshot.topics}
-          isSubmitting={isSubmitting}
+          isPending={isSaving || isSubmitting}
           onConfirmShare={handleConfirmShare}
           onGoToPreOpinions={() => navigate(ROUTES.PRE_OPINIONS(numGatheringId, numMeetingId))}
           onGoToBook={() => navigate(ROUTES.BOOK_DETAIL(preOpinion.book.bookId))}

--- a/src/pages/PreOpinions/PreOpinionWritePage.tsx
+++ b/src/pages/PreOpinions/PreOpinionWritePage.tsx
@@ -14,6 +14,11 @@ import { ROUTES } from '@/shared/constants/routes'
 import { Card, Spinner } from '@/shared/ui'
 import { useGlobalModalStore } from '@/store'
 
+function normalizeAnswer(raw: string): string | null {
+  const trimmed = raw.trim()
+  return trimmed || null
+}
+
 export default function PreOpinionWritePage() {
   const { gatheringId, meetingId } = useParams<{ gatheringId: string; meetingId: string }>()
   const numGatheringId = Number(gatheringId)
@@ -95,10 +100,9 @@ export default function PreOpinionWritePage() {
       const raw = answersRef.current.has(topic.topicId)
         ? answersRef.current.get(topic.topicId)!
         : (topic.content ?? '')
-      const trimmed = raw.trim()
       return {
         topicId: topic.topicId,
-        content: trimmed || null,
+        content: normalizeAnswer(raw),
       }
     })
 
@@ -142,9 +146,11 @@ export default function PreOpinionWritePage() {
       description: t.topicDescription,
       topicTypeLabel: t.topicTypeLabel,
       confirmOrder: t.confirmOrder,
-      content: answersRef.current.has(t.topicId)
-        ? answersRef.current.get(t.topicId)!
-        : (t.content ?? null),
+      content: normalizeAnswer(
+        answersRef.current.has(t.topicId)
+          ? answersRef.current.get(t.topicId)!
+          : (t.content ?? ''),
+      ),
     }))
 
     setPreviewSnapshot({

--- a/src/pages/Retrospectives/personal/PersonalRetrospectivePage.tsx
+++ b/src/pages/Retrospectives/personal/PersonalRetrospectivePage.tsx
@@ -31,7 +31,7 @@ export default function PersonalRetrospectivePage() {
 
   // 작성 모드: 작성 폼 API만 호출
   const { data, isLoading, isError } = usePersonalRetrospective(
-    { gatheringId, meetingId },
+    { meetingId },
     !isEditMode
   )
 

--- a/src/pages/Retrospectives/personal/PersonalRetrospectivePage.tsx
+++ b/src/pages/Retrospectives/personal/PersonalRetrospectivePage.tsx
@@ -30,10 +30,7 @@ export default function PersonalRetrospectivePage() {
   const { openError } = useGlobalModalStore()
 
   // 작성 모드: 작성 폼 API만 호출
-  const { data, isLoading, isError } = usePersonalRetrospective(
-    { meetingId },
-    !isEditMode
-  )
+  const { data, isLoading, isError } = usePersonalRetrospective({ meetingId }, !isEditMode)
 
   // 수정 모드: 수정 폼 API만 호출
   const {

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -12,7 +12,6 @@ export const ROUTES = {
   BOOKS: '/books',
   BOOK_DETAIL: (id: number | string) => `/books/${id}`,
   BOOK_REVIEW_HISTORY: (id: number | string) => `/books/${id}/reviews`,
-  BOOK_SEARCH: '/books/search',
 
   // Gatherings
   GATHERINGS: '/gatherings',

--- a/src/shared/ui/GlobalModalHost.tsx
+++ b/src/shared/ui/GlobalModalHost.tsx
@@ -42,13 +42,13 @@ import { useGlobalModalStore } from '@/store'
  * ```
  */
 export function GlobalModalHost() {
-  const { isOpen, type, title, description, buttons } = useGlobalModalStore()
+  const { isOpen, title, description, buttons } = useGlobalModalStore()
 
   if (!isOpen) {
     return null
   }
 
-  const footerVariant = type === 'confirm' ? 'double' : 'full'
+  const footerVariant = buttons.length >= 2 ? 'double' : 'full'
   //에러, 얼럿일 경우 디자인 맞춰서 수정해야 함
 
   return (

--- a/src/shared/ui/StarRatingFilter.tsx
+++ b/src/shared/ui/StarRatingFilter.tsx
@@ -59,13 +59,23 @@ function StarRatingFilter({
   const handleStarClick = (rating: number) => {
     if (!tempRange) {
       setTempRange({ min: rating, max: rating })
-    } else if (tempRange.min === rating && tempRange.max === rating) {
-      setTempRange(null)
     } else if (rating < tempRange.min) {
+      // 범위 밖 (아래) → min 확장
       setTempRange({ min: rating, max: tempRange.max })
     } else if (rating > tempRange.max) {
+      // 범위 밖 (위) → max 확장
       setTempRange({ min: tempRange.min, max: rating })
+    } else if (rating === tempRange.min && rating === tempRange.max) {
+      // 단일 선택된 별 클릭 → 전체 해제
+      setTempRange(null)
+    } else if (rating === tempRange.min) {
+      // 최솟값 클릭 → min 취소, max만 남김
+      setTempRange({ min: tempRange.max, max: tempRange.max })
+    } else if (rating === tempRange.max) {
+      // 최댓값 클릭 → max 취소, min만 남김
+      setTempRange({ min: tempRange.min, max: tempRange.min })
     } else {
+      // 범위 내 중간 값 클릭 → 해당 별 단일 선택
       setTempRange({ min: rating, max: rating })
     }
   }

--- a/src/store/globalModalStore.ts
+++ b/src/store/globalModalStore.ts
@@ -41,6 +41,8 @@ export type ModalState = {
 export type ConfirmModalOptions = {
   /** 확인 버튼 텍스트 (기본값: '확인') */
   confirmText?: string
+  /** 취소 버튼 텍스트 (기본값: '취소') */
+  cancelText?: string
   /** 확인 버튼 variant (기본값: 'primary') */
   variant?: Extract<ModalButtonVariant, 'primary' | 'danger'>
 }
@@ -129,7 +131,7 @@ export const useGlobalModalStore = create<GlobalModalStore>((set, get) => ({
         description,
         buttons: [
           {
-            text: '취소',
+            text: options?.cancelText || '취소',
             variant: 'secondary',
             onClick: handleCancel,
           },

--- a/src/store/globalModalStore.ts
+++ b/src/store/globalModalStore.ts
@@ -37,6 +37,17 @@ export type ModalState = {
   buttons: ModalButton[]
 }
 
+/** Alert 모달 옵션 */
+export type AlertModalOptions = {
+  /** 보조 액션 버튼 (예: '내 책장 보기') */
+  secondaryAction?: {
+    /** 버튼 텍스트 */
+    text: string
+    /** 클릭 핸들러 */
+    onClick: () => void
+  }
+}
+
 /** Confirm 모달 옵션 */
 export type ConfirmModalOptions = {
   /** 확인 버튼 텍스트 (기본값: '확인') */
@@ -50,7 +61,12 @@ export type ConfirmModalOptions = {
 /** 전역 모달 스토어 타입 */
 type GlobalModalStore = ModalState & {
   /** Alert 모달 열기 */
-  openAlert: (title: string, description: string, onClose?: () => void) => void
+  openAlert: (
+    title: string,
+    description: string,
+    onClose?: () => void,
+    options?: AlertModalOptions
+  ) => void
   /** Error 모달 열기 */
   openError: (title: string, description: string, onClose?: () => void) => void
   /** Confirm 모달 열기 (Promise 반환) */
@@ -74,22 +90,40 @@ const initialState: ModalState = {
 export const useGlobalModalStore = create<GlobalModalStore>((set, get) => ({
   ...initialState,
 
-  openAlert: (title: string, description: string, onClose?: () => void) => {
+  openAlert: (
+    title: string,
+    description: string,
+    onClose?: () => void,
+    options?: AlertModalOptions
+  ) => {
+    const buttons: ModalButton[] = []
+
+    if (options?.secondaryAction) {
+      buttons.push({
+        text: options.secondaryAction.text,
+        variant: 'secondary',
+        onClick: () => {
+          get().close()
+          options.secondaryAction!.onClick()
+        },
+      })
+    }
+
+    buttons.push({
+      text: '확인',
+      variant: 'primary',
+      onClick: () => {
+        get().close()
+        onClose?.()
+      },
+    })
+
     set({
       isOpen: true,
       type: 'alert',
       title,
       description,
-      buttons: [
-        {
-          text: '확인',
-          variant: 'primary',
-          onClick: () => {
-            get().close()
-            onClose?.()
-          },
-        },
-      ],
+      buttons,
     })
   },
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- APPOINT-065
    - [사전 의견 공유 후 액션](https://www.notion.so/337d0cee0cba803586bdc7decb353a8a?pvs=21)
        - 저장하기 → 임시저장 버튼 명칭 변경
        - 공유하기 후 미리보기 모달 → 내 책장 or 사전의견 조회 navigate
    - [사전 의견 저장 후 홈에서 재진입 오류](https://www.notion.so/337d0cee0cba80e9a09fc4391b83f59c?pvs=21)
        - 홈에서 사전의견 작성 페이지 navigate
- APPOINT-070
    - [사전의견 작성 후 조회 시 줄바꿈](https://www.notion.so/337d0cee0cba801e8e89ccdade8452b0?pvs=21)
        - 주제설명, 주제에 대한 의견 줄바꿈 처리=
    - [사전의견 삭제 오류](https://www.notion.so/334d0cee0cba80b99869da08965ee8b5?pvs=21)
        - API path 수정
- BOOK-100
    - [책 기록 상태 토글버튼 오류](https://www.notion.so/336d0cee0cba80d69329e07f51434d4c?pvs=21)
        - API path 수정
- BOOK-400
    - [홈 책 추가 버튼 오류](https://www.notion.so/33ad0cee0cba801ca4bbc02a6140bef3?pvs=21)
        - 홈에서 책 추가하기 클릭 시 책 추가 모달 open
- SHELF-400
    - [별점 필터링 동작 오류](https://www.notion.so/336d0cee0cba80348ba4f6e790dbc36e?pvs=21)
        - min~max 클릭 상태에서 min 누르면 max만 남고, max 누르면 min만 남도록 수정
        - min~max 사이를 누르면 해당 별점으로 초기화, 초과 누르면 범위 늘어남
- REVIEW-100
    - [개인회고 작성 불가](https://www.notion.so/335d0cee0cba801dadb9fa439f58d446?pvs=21)
        - API path 수정

## 🔧 변경 사항
상동

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 사전 의견 공유 미리보기 모달 및 리뷰 미리보기 컴포넌트 추가
  * 홈 화면에서 책 추가용 모달 도입

* **개선사항**
  * 기록 생성/수정/삭제 시 토스트 알림 추가
  * 사전 의견 기본 저장 버튼 라벨을 "임시저장"으로 변경
  * 별점 필터 선택 동작 및 주제 설명 줄바꿈 처리 개선
  * 공유/작성 흐름을 미리보기 기반으로 개선하고 관련 네비게이션 보완
  * 도서 관련 개인 식별자 활용으로 일부 도서 기능 동작이 갱신됨
  * 확인 모달 취소 텍스트 커스터마이징 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->