### PR TITLE
[fix] 1차 QA 관련 에러 (약속, 주제)

### DIFF
--- a/src/features/meetings/meetings.endpoints.ts
+++ b/src/features/meetings/meetings.endpoints.ts
@@ -23,7 +23,7 @@ export const MEETINGS_ENDPOINTS = {
   JOIN: (meetingId: number) => `${API_PATHS.MEETINGS}/${meetingId}/join`,
 
   // 약속 참가취소 (DELETE /api/meetings/{meetingId}/join)
-  CANCEL_JOIN: (meetingId: number) => `${API_PATHS.MEETINGS}/${meetingId}/join`,
+  CANCEL_JOIN: (meetingId: number) => `${API_PATHS.MEETINGS}/${meetingId}/cancel`,
 
   // 약속 수정 (PATCH /api/meetings/{meetingId})
   UPDATE: (meetingId: number) => `${API_PATHS.MEETINGS}/${meetingId}`,

--- a/src/features/meetings/meetings.endpoints.ts
+++ b/src/features/meetings/meetings.endpoints.ts
@@ -22,7 +22,7 @@ export const MEETINGS_ENDPOINTS = {
   // 약속 참가신청 (POST /api/meetings/{meetingId}/join)
   JOIN: (meetingId: number) => `${API_PATHS.MEETINGS}/${meetingId}/join`,
 
-  // 약속 참가취소 (DELETE /api/meetings/{meetingId}/join)
+  // 약속 참가취소 (DELETE /api/meetings/{meetingId}/cancel)
   CANCEL_JOIN: (meetingId: number) => `${API_PATHS.MEETINGS}/${meetingId}/cancel`,
 
   // 약속 수정 (PATCH /api/meetings/{meetingId})

--- a/src/features/topics/components/ConfirmModalTopicCard.tsx
+++ b/src/features/topics/components/ConfirmModalTopicCard.tsx
@@ -40,7 +40,7 @@ export default function ConfirmModalTopicCard({
               </Badge>
             </div>
           </div>
-          <p className="typo-body4 text-grey-700">{description}</p>
+          <p className="typo-body4 text-grey-700 whitespace-pre-wrap">{description}</p>
           <p className="typo-body6 text-grey-600">제안 : {createdByNickname}</p>
         </div>
       </Card>

--- a/src/features/topics/components/ProposedTopicList.tsx
+++ b/src/features/topics/components/ProposedTopicList.tsx
@@ -1,7 +1,6 @@
 import { useInfiniteScroll } from '@/shared/hooks/useInfiniteScroll'
 
 import type { ProposedTopicItem } from '../topics.types'
-import DefaultTopicCard from './DefaultTopicCard'
 import TopicCard from './TopicCard'
 import TopicListSkeleton from './TopicListSkeleton'
 
@@ -13,6 +12,7 @@ type ProposedTopicListProps = {
   gatheringId: number
   meetingId: number
   confirmedTopic: boolean
+  canLike: boolean
 }
 
 export default function ProposedTopicList({
@@ -23,6 +23,7 @@ export default function ProposedTopicList({
   gatheringId,
   meetingId,
   confirmedTopic,
+  canLike,
 }: ProposedTopicListProps) {
   // 무한 스크롤: IntersectionObserver로 다음 페이지 로드
   const observerRef = useInfiniteScroll(onLoadMore, {
@@ -32,13 +33,11 @@ export default function ProposedTopicList({
 
   return (
     <div className="flex flex-col gap-small">
-      {/* 기본 주제는 항상 표시 */}
-      <DefaultTopicCard />
-
       {/* 제안된 주제 목록 */}
-      {topics.length > 0 && (
-        <ul className="flex flex-col gap-small">
-          {topics.map((topic) => (
+
+      <ul className="flex flex-col gap-small">
+        {topics.length > 0 ? (
+          topics.map((topic) => (
             <li key={topic.topicId}>
               <TopicCard
                 title={topic.title}
@@ -51,12 +50,16 @@ export default function ProposedTopicList({
                 gatheringId={gatheringId}
                 meetingId={meetingId}
                 topicId={topic.topicId}
-                isLikeDisabled={confirmedTopic}
+                isLikeDisabled={confirmedTopic || !canLike}
               />
             </li>
-          ))}
-        </ul>
-      )}
+          ))
+        ) : (
+          <li className="flex items-center justify-center py-large border-none mt-base">
+            <p className="typo-body3 text-grey-600">제안된 주제가 없습니다.</p>
+          </li>
+        )}
+      </ul>
 
       {/* 무한 스크롤 로딩 상태 */}
       {isFetchingNextPage && <TopicListSkeleton />}

--- a/src/features/topics/components/TopicCard.tsx
+++ b/src/features/topics/components/TopicCard.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react'
+
 import { showErrorToast, showToast } from '@/shared/lib/toast'
 import { Badge, Card, LikeButton, TextButton } from '@/shared/ui'
 import { useGlobalModalStore } from '@/store'
@@ -18,7 +20,7 @@ type TopicCardProps = {
   topicId?: number
 }
 
-export default function TopicCard({
+function TopicCard({
   title,
   topicTypeLabel,
   description,
@@ -108,3 +110,5 @@ export default function TopicCard({
     </Card>
   )
 }
+
+export default memo(TopicCard)

--- a/src/features/topics/components/TopicCard.tsx
+++ b/src/features/topics/components/TopicCard.tsx
@@ -96,7 +96,7 @@ function TopicCard({
           </TextButton>
         )}
       </div>
-      <p className="typo-body4 text-grey-700">{description}</p>
+      <p className="typo-body4 text-grey-700 whitespace-pre-wrap">{description}</p>
       <div className="flex justify-between items-end">
         <p className="typo-body6 text-grey-600">제안 : {createdByNickname}</p>
         <LikeButton

--- a/src/features/topics/components/TopicHeader.tsx
+++ b/src/features/topics/components/TopicHeader.tsx
@@ -3,29 +3,28 @@ import { Check } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 
 import type { MeetingProgressStatus } from '@/features/meetings/meetings.types'
+import type { ConfirmedTopicActions, ProposedTopicActions } from '@/features/topics/topics.types'
 import { ROUTES } from '@/shared/constants'
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui'
 
 type ProposedHeaderProps = {
   activeTab: 'PROPOSED'
-  actions: { canConfirm: boolean; canSuggest: boolean }
   confirmedTopic: boolean
   confirmedTopicDate: string | null
   proposedTopicsCount: number
   onOpenChange: (open: boolean) => void
   gatheringId: number
   meetingId: number
-}
+} & ProposedTopicActions
 
 type ConfirmedHeaderProps = {
   activeTab: 'CONFIRMED'
-  actions: { canViewPreOpinions: boolean; canWritePreOpinions: boolean }
   confirmedTopic: boolean
   confirmedTopicDate: string | null
   progressStatus: MeetingProgressStatus
   gatheringId: number
   meetingId: number
-}
+} & ConfirmedTopicActions
 
 type TopicHeaderProps = ProposedHeaderProps | ConfirmedHeaderProps
 

--- a/src/features/topics/hooks/useLikeTopic.ts
+++ b/src/features/topics/hooks/useLikeTopic.ts
@@ -19,7 +19,7 @@ import { topicQueryKeys } from './topicQueryKeys'
  * 주제 좋아요를 토글하고 낙관적 업데이트를 적용합니다.
  * - onMutate: 즉시 UI 업데이트 (isLiked 토글, likeCount 증감)
  * - onError: 실패 시 이전 상태로 롤백
- * - onSettled: 서버 데이터와 동기화
+ * - 목록 순서는 새로고침 시에만 변경됨 (자동 리페치 없음)
  *
  * @example
  * ```tsx
@@ -47,10 +47,9 @@ export const useLikeTopic = () => {
 
     // 낙관적 업데이트: 즉시 UI 업데이트
     onMutate: async (variables) => {
-      const { topicId } = variables
+      const { gatheringId, meetingId, topicId } = variables
 
-      // Partial matching을 위한 base 쿼리 키 (pageSize와 무관하게 모든 쿼리 매칭)
-      const baseQueryKey = topicQueryKeys.proposedLists()
+      const baseQueryKey = topicQueryKeys.proposedList({ gatheringId, meetingId })
 
       // 진행 중인 모든 관련 쿼리 취소 (낙관적 업데이트 덮어쓰기 방지)
       await queryClient.cancelQueries({ queryKey: baseQueryKey })
@@ -98,14 +97,6 @@ export const useLikeTopic = () => {
           queryClient.setQueryData(queryKey, data)
         })
       }
-    },
-
-    // 성공/실패 여부와 상관없이 서버 데이터와 동기화
-    onSettled: () => {
-      // 모든 제안된 주제 목록 쿼리 무효화
-      queryClient.invalidateQueries({
-        queryKey: topicQueryKeys.proposedLists(),
-      })
     },
   })
 }

--- a/src/features/topics/hooks/useProposedTopics.ts
+++ b/src/features/topics/hooks/useProposedTopics.ts
@@ -62,6 +62,5 @@ export const useProposedTopics = (
     // 캐시 데이터 10분간 유지
     gcTime: 10 * 60 * 1000,
     staleTime: 0,
-    // 탭 포커스 시 자동 refetch 비활성화 (라우팅 재진입 시에만 갱신)
   })
 }

--- a/src/features/topics/hooks/useProposedTopics.ts
+++ b/src/features/topics/hooks/useProposedTopics.ts
@@ -61,5 +61,7 @@ export const useProposedTopics = (
     },
     // 캐시 데이터 10분간 유지
     gcTime: 10 * 60 * 1000,
+    staleTime: 0,
+    // 탭 포커스 시 자동 refetch 비활성화 (라우팅 재진입 시에만 갱신)
   })
 }

--- a/src/features/topics/topics.mock.ts
+++ b/src/features/topics/topics.mock.ts
@@ -438,6 +438,7 @@ export const getMockProposedTopics = (
     actions: {
       canConfirm: true,
       canSuggest: true,
+      canLike: true,
     },
   }
 }

--- a/src/features/topics/topics.types.ts
+++ b/src/features/topics/topics.types.ts
@@ -131,30 +131,19 @@ export type GetConfirmedTopicsParams = {
   cursorTopicId?: number
 }
 
-/**
- * 제안된 주제 조회 응답 타입
- */
-export type GetProposedTopicsResponse = CursorPaginatedResponse<
-  ProposedTopicItem,
-  ProposedTopicCursor
-> & {
-  /** 액션 권한 정보 */
+/** 제안된 주제 액션 버튼 타입 */
+export type ProposedTopicActions = {
   actions: {
     /** 주제 확정 가능 여부 */
     canConfirm: boolean
     /** 주제 제안 가능 여부 */
     canSuggest: boolean
+    /** 좋야요 가능 여부 */
+    canLike: boolean
   }
 }
-
-/**
- * 확정된 주제 조회 응답 타입
- */
-export type GetConfirmedTopicsResponse = CursorPaginatedResponse<
-  ConfirmedTopicItem,
-  ConfirmedTopicCursor
-> & {
-  /** 액션 권한 정의 */
+/** 확정된 주제 액션 버튼 타입 */
+export type ConfirmedTopicActions = {
   actions: {
     /** 사전 의견 조회 가능 여부 */
     canViewPreOpinions: boolean
@@ -162,6 +151,24 @@ export type GetConfirmedTopicsResponse = CursorPaginatedResponse<
     canWritePreOpinions: boolean
   }
 }
+
+/**
+ * 제안된 주제 조회 응답 타입
+ */
+export type GetProposedTopicsResponse = CursorPaginatedResponse<
+  ProposedTopicItem,
+  ProposedTopicCursor
+> &
+  ProposedTopicActions
+
+/**
+ * 확정된 주제 조회 응답 타입
+ */
+export type GetConfirmedTopicsResponse = CursorPaginatedResponse<
+  ConfirmedTopicItem,
+  ConfirmedTopicCursor
+> &
+  ConfirmedTopicActions
 
 /**
  * 주제 삭제 요청 파라미터

--- a/src/pages/Meetings/MeetingCreatePage.tsx
+++ b/src/pages/Meetings/MeetingCreatePage.tsx
@@ -425,6 +425,7 @@ export default function MeetingCreatePage() {
                   errorMessage={errors?.maxParticipants ?? undefined}
                   value={maxParticipants ?? ''}
                   onChange={(e) => setMaxParticipants(e.target.value)}
+                  onWheel={(e) => e.currentTarget.blur()}
                   min={1}
                   max={gatheringMaxCount}
                 />

--- a/src/pages/Meetings/MeetingDetailPage.tsx
+++ b/src/pages/Meetings/MeetingDetailPage.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/features/topics'
 import SubPageHeader from '@/shared/components/SubPageHeader'
 import { ROUTES } from '@/shared/constants'
+import { useDeferredLoading } from '@/shared/hooks'
 import { showErrorToast } from '@/shared/lib/toast'
 import { Spinner, Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/ui'
 
@@ -62,6 +63,7 @@ export default function MeetingDetailPage() {
   const {
     data: proposedTopicsInfiniteData,
     isLoading: isProposedLoading,
+    isRefetching: isProposedRefetching,
     error: proposedError,
     refetch: refetchProposed,
     fetchNextPage: fetchNextProposedPage,
@@ -71,6 +73,8 @@ export default function MeetingDetailPage() {
     gatheringId: gatheringId,
     meetingId: meetingId,
   })
+
+  const showProposedSkeleton = useDeferredLoading(isProposedRefetching || isProposedLoading)
 
   // 확정된 주제 조회 (무한 스크롤)
   const {
@@ -147,7 +151,11 @@ export default function MeetingDetailPage() {
 
             <Tabs
               value={activeTab}
-              onValueChange={(value) => setUserSelectedTab(value as TopicStatus)}
+              onValueChange={(value) => {
+                const tab = value as TopicStatus
+                setUserSelectedTab(tab)
+                if (tab === 'PROPOSED') void refetchProposed()
+              }}
               className="gap-medium"
             >
               <TabsList className="border-b border-grey-300" size="medium">
@@ -174,7 +182,7 @@ export default function MeetingDetailPage() {
                     message="제안 주제를 불러오지 못했습니다"
                     onRetry={() => refetchProposed()}
                   />
-                ) : isProposedLoading || !proposedTopicsInfiniteData ? (
+                ) : showProposedSkeleton || !proposedTopicsInfiniteData ? (
                   <TopicSkeleton />
                 ) : (
                   <div className="flex flex-col gap-base">
@@ -198,6 +206,7 @@ export default function MeetingDetailPage() {
                       onLoadMore={fetchNextProposedPage}
                       gatheringId={gatheringId}
                       meetingId={meetingId}
+                      canLike={proposedTopicsInfiniteData.pages[0].actions.canLike}
                     />
                   </div>
                 )}

--- a/src/pages/Retrospectives/meeting/MeetingRetrospectiveCreatePage.tsx
+++ b/src/pages/Retrospectives/meeting/MeetingRetrospectiveCreatePage.tsx
@@ -8,7 +8,8 @@ import {
   useCollectedAnswers,
   useCreateSttJob,
 } from '@/features/retrospectives/meeting'
-import SubPageHeader from '@/shared/components/SubPageHeader'
+import FormPageHeader from '@/shared/components/FormPageHeader'
+// import SubPageHeader from '@/shared/components/SubPageHeader'
 import { ROUTES } from '@/shared/constants'
 import { useInfiniteScroll } from '@/shared/hooks/useInfiniteScroll'
 import { showErrorToast } from '@/shared/lib/toast'
@@ -116,28 +117,42 @@ export default function MeetingRetrospectiveCreatePage() {
 
   return (
     <>
-      <SubPageHeader label="뒤로가기" to={ROUTES.MEETING_RETROSPECTIVE(gatheringId, meetingId)} />
+      <FormPageHeader
+        title="약속 회고"
+        subTitle="사전 의견과 녹음 파일을 분석하여 약속 회고를 자동 생성해요"
+        to={ROUTES.MEETING_DETAIL(gatheringId, meetingId)}
+      >
+        <Button
+          variant="ai"
+          size="small"
+          onClick={handleStartAiSummary}
+          className="px-medium"
+          disabled={totalCount === 0 || sttMutation.isPending}
+        >
+          AI 요약 시작하기
+        </Button>
+      </FormPageHeader>
+      {/* <SubPageHeader label="뒤로가기" to={ROUTES.MEETING_DETAIL(gatheringId, meetingId)} /> */}
 
       {/* 헤더: 타이틀 + 설명 + AI 요약 시작하기 버튼 */}
-      <div className="sticky top-[calc(var(--spacing-gnb-height)+59px)] z-30 bg-white shadow-drop-bottom">
-        <div className="mx-auto max-w-layout-max px-layout-padding flex items-center justify-between pb-small">
-          <div className="flex flex-col gap-xtiny">
-            <h3 className="text-black typo-heading3">약속 회고</h3>
-            <p className="text-grey-600 typo-caption1">
-              사전 의견과 녹음 파일을 분석하여 약속 회고를 자동 생성해요
-            </p>
-          </div>
-          <Button
-            variant="ai"
-            size="small"
-            onClick={handleStartAiSummary}
-            className="px-medium"
-            disabled={totalCount === 0 || sttMutation.isPending}
-          >
-            AI 요약 시작하기
-          </Button>
+
+      {/* <div className="mx-auto max-w-layout-max px-layout-padding flex items-center justify-between pb-small">
+        <div className="flex flex-col gap-xtiny">
+          <h3 className="text-black typo-heading3">약속 회고</h3>
+          <p className="text-grey-600 typo-caption1">
+            사전 의견과 녹음 파일을 분석하여 약속 회고를 자동 생성해요
+          </p>
         </div>
-      </div>
+        <Button
+          variant="ai"
+          size="small"
+          onClick={handleStartAiSummary}
+          className="px-medium"
+          disabled={totalCount === 0 || sttMutation.isPending}
+        >
+          AI 요약 시작하기
+        </Button>
+      </div> */}
 
       {/* 두 패널 영역 */}
       <div className="mx-auto max-w-layout-max px-layout-padding flex gap-medium mt-base">

--- a/src/shared/components/FormPageHeader.tsx
+++ b/src/shared/components/FormPageHeader.tsx
@@ -9,6 +9,8 @@ import { TextButton } from '@/shared/ui/TextButton'
 interface FormPageHeaderBaseProps {
   /** 페이지 제목 */
   title: string
+  /** 페이지 소제목 */
+  subTitle?: string
   /** 액션 버튼 비활성화 여부 */
   isActionDisabled?: boolean
   /** 이동할 경로. 지정하지 않으면 navigate(-1)로 뒤로가기 */
@@ -66,6 +68,7 @@ export type FormPageHeaderProps = FormPageHeaderWithAction | FormPageHeaderWithC
  * ```
  */
 export default function FormPageHeader({
+  subTitle,
   title,
   actionLabel,
   onAction,
@@ -101,7 +104,14 @@ export default function FormPageHeader({
           뒤로가기
         </TextButton>
         <div className="flex items-center justify-between py-large">
-          <h2 className="text-black typo-heading3">{title}</h2>
+          <div>
+            <h2 className="text-black typo-heading3">{title}</h2>
+            {subTitle && (
+              <p className="text-grey-600 typo-caption1 pt-tiny">
+                {subTitle}
+              </p>
+            )}
+          </div>
           {children ? (
             <div className="flex items-center gap-xsmall">{children}</div>
           ) : (

--- a/src/shared/components/FormPageHeader.tsx
+++ b/src/shared/components/FormPageHeader.tsx
@@ -106,11 +106,7 @@ export default function FormPageHeader({
         <div className="flex items-center justify-between py-large">
           <div>
             <h2 className="text-black typo-heading3">{title}</h2>
-            {subTitle && (
-              <p className="text-grey-600 typo-caption1 pt-tiny">
-                {subTitle}
-              </p>
-            )}
+            {subTitle && <p className="text-grey-600 typo-caption1 pt-tiny">{subTitle}</p>}
           </div>
           {children ? (
             <div className="flex items-center gap-xsmall">{children}</div>

--- a/src/shared/ui/GlobalModalHost.tsx
+++ b/src/shared/ui/GlobalModalHost.tsx
@@ -1,6 +1,11 @@
 /**
  * @file GlobalModalHost.tsx
  * @description 전역 모달 호스트 컴포넌트
+ *
+ * useGlobalModalStore의 상태를 구독하여 모달을 렌더링합니다.
+ * {@link useGlobalModalStore} → src/store/globalModalStore.ts
+ *
+ * 반드시 App.tsx 최상단에 한 번만 마운트하세요.
  */
 
 import { Button } from '@/shared/ui/Button'
@@ -8,6 +13,7 @@ import {
   Modal,
   ModalBody,
   ModalContent,
+  ModalDescription,
   ModalFooter,
   ModalHeader,
   ModalTitle,
@@ -56,6 +62,7 @@ export function GlobalModalHost() {
       <ModalContent variant="normal" className="h-auto w-fit min-w-md">
         <ModalHeader hideCloseButton>
           <ModalTitle className="text-black typo-subtitle2">{title}</ModalTitle>
+          <ModalDescription className="sr-only">{description}</ModalDescription>
         </ModalHeader>
         <ModalBody>
           <p className="whitespace-pre-line typo-body4 text-grey-700">{description}</p>

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -225,12 +225,12 @@ function ModalBody({ className, ...props }: React.HTMLAttributes<HTMLDivElement>
 }
 
 const modalFooterVariants = cva(
-  ['flex items-center shrink-0', 'px-xlarge pt-base pb-large border-t border-grey-300'],
+  ['flex items-center shrink-0', 'px-xlarge pt-base pb-large border-t border-grey-300 justify-end'],
   {
     variants: {
       variant: {
-        double: 'justify-end gap-small',
-        full: 'justify-stretch',
+        double: 'gap-small',
+        full: '',
       },
     },
     defaultVariants: {

--- a/src/store/globalModalStore.ts
+++ b/src/store/globalModalStore.ts
@@ -1,6 +1,11 @@
 /**
  * @file globalModalStore.ts
  * @description 전역 모달 상태 관리 스토어 (Zustand)
+ *
+ * 이 스토어의 상태를 구독하여 실제 모달을 렌더링하는 컴포넌트:
+ * {@link GlobalModalHost} → src/shared/ui/GlobalModalHost.tsx
+ *
+ * GlobalModalHost가 App.tsx에 마운트되어 있어야 모달이 화면에 표시됩니다.
  */
 
 import { create } from 'zustand'


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

### APPOINT_010

- [x] [약속 상세] 약속 참가 신청 취소 오류 
- 약속 참가 신청 취소 API 엔드포인트 경로 오류 수정 (/join → /cancel)
- [x] [약속 관리] 약속 승인 버튼 클릭 시 werning
- 전역 모달 ModalDescription 누락으로 발생하는 접근성 warning 해결

### MEET-400

- [x] [약속 생성] 약속 생성 시 참가 인원 입력 필드에서 스크롤 이슈
- 약속 생성 페이지 참가 인원 입력 필드 휠 스크롤 시 값 변경되는 이슈 수정

### APPOINT-100
- [x] [약속 회고] 뒤로가기 버튼 경로 수정
- [x] [약속 회고] 헤더 UI 버그
- 약속 회고 뒤로가기 경로 오류 수정 및 헤더 UI 버그 수정

### APPOINT-020

- [x] [약속 상세] 좋아요 누를때 실시으로 순서가 변경됨 
- 약속 상세 좋아요 클릭 시 목록 순서가 실시간으로 변경되는 문제 수정 (새로고침 시에만 반영)
- [x] [약속 상세] 참가 신청하지 않은 모임원이 제안된 좋아요 클릭 가능하도록 노출되어 있음 (클릭 불가능하도록 수정 필요)
- 참가 신청하지 않은 사용자에게 좋아요 버튼이 활성화되어 노출되는 문제 수정


## 📄 기타
아래 버그는 현재 잘 되는 것 같아서 따로 수정한 건 없습니다.  버그 발견되면 제보 부탁드립니다.
- [약속 상세] 좋아요 버튼 되다 안되다 함
- [약속 상세] 밑에 있는 주제에 좋아요 눌렀는데 정렬이 바뀌면서 좋아요 버튼 활성화는 밑에 있는 버튼에 됨



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **새로운 기능**
  * 제안된 주제에 좋아요 권한 추가 및 UI 반영

* **버그 수정**
  * 숫자 입력 필드에서 마우스 휠로 값이 바뀌는 현상 차단
  * 회의 취소 관련 경로 수정

* **개선사항**
  * 제안된 주제 목록의 로딩 표시 개선 및 데이터 신선도 조정
  * 회고 페이지 헤더 UI 개편 및 폼 헤더에 부제목 지원 추가
  * 모달 접근성 설명 추가
  * 토픽 카드 렌더링 성능 개선(메모이제이션)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->