### PR TITLE
fix: 약속 참가 신청 후 내 약속 탭 카운트 미갱신 (#119)

### DIFF
--- a/src/features/meetings/hooks/useCancelJoinMeeting.ts
+++ b/src/features/meetings/hooks/useCancelJoinMeeting.ts
@@ -10,6 +10,7 @@ import type { ApiResponse } from '@/api/types'
 import { cancelJoinMeeting } from '@/features/meetings'
 
 import { meetingQueryKeys } from './meetingQueryKeys'
+import { myMeetingQueryKeys } from './myMeetingQueryKeys'
 
 /**
  * 약속 참가취소 mutation 훅
@@ -17,6 +18,8 @@ import { meetingQueryKeys } from './meetingQueryKeys'
  * @description
  * 약속 참가를 취소하고 관련 쿼리 캐시를 무효화합니다.
  * - 약속 상세 캐시 무효화
+ * - 내 약속 탭 카운트 캐시 무효화
+ * - 내 약속 목록 캐시 무효화
  *
  */
 export const useCancelJoinMeeting = () => {
@@ -29,6 +32,10 @@ export const useCancelJoinMeeting = () => {
       queryClient.invalidateQueries({
         queryKey: meetingQueryKeys.detail(variables),
       })
+      // 내 약속 탭 카운트 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: myMeetingQueryKeys.tabCounts() })
+      // 내 약속 목록 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: myMeetingQueryKeys.lists() })
     },
   })
 }

--- a/src/features/meetings/hooks/useConfirmMeeting.ts
+++ b/src/features/meetings/hooks/useConfirmMeeting.ts
@@ -10,6 +10,7 @@ import { gatheringQueryKeys } from '@/features/gatherings'
 import { confirmMeeting, type ConfirmMeetingResponse } from '@/features/meetings'
 
 import { meetingQueryKeys } from './meetingQueryKeys'
+import { myMeetingQueryKeys } from './myMeetingQueryKeys'
 
 /**
  * 약속 승인 mutation 훅
@@ -19,6 +20,9 @@ import { meetingQueryKeys } from './meetingQueryKeys'
  * - 약속 승인 리스트 캐시 무효화
  * - 약속 승인 카운트 캐시 무효화
  * - 모임 약속 리스트 캐시 무효화
+ * - 약속 상세 캐시 무효화
+ * - 내 약속 탭 카운트 캐시 무효화
+ * - 내 약속 목록 캐시 무효화
  *
  * @example
  * const confirmMutation = useConfirmMeeting(gatheringId)
@@ -29,13 +33,19 @@ export const useConfirmMeeting = (gatheringId: number) => {
 
   return useMutation<ApiResponse<ConfirmMeetingResponse>, ApiError, number>({
     mutationFn: (meetingId: number) => confirmMeeting(meetingId),
-    onSuccess: () => {
+    onSuccess: (_data, meetingId) => {
       // 약속 승인 관련 모든 캐시 무효화 (리스트 + 카운트)
       queryClient.invalidateQueries({
         queryKey: meetingQueryKeys.approvals(),
       })
       // 모임 약속 리스트 캐시 무효화
       queryClient.invalidateQueries({ queryKey: gatheringQueryKeys.meetings(gatheringId) })
+      // 약속 상세 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: meetingQueryKeys.detail(meetingId) })
+      // 내 약속 탭 카운트 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: myMeetingQueryKeys.tabCounts() })
+      // 내 약속 목록 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: myMeetingQueryKeys.lists() })
     },
   })
 }

--- a/src/features/meetings/hooks/useDeleteMeeting.ts
+++ b/src/features/meetings/hooks/useDeleteMeeting.ts
@@ -11,6 +11,7 @@ import { gatheringQueryKeys } from '@/features/gatherings'
 import { deleteMeeting } from '@/features/meetings'
 
 import { meetingQueryKeys } from './meetingQueryKeys'
+import { myMeetingQueryKeys } from './myMeetingQueryKeys'
 
 /**
  * 약속 삭제 mutation 훅
@@ -19,6 +20,9 @@ import { meetingQueryKeys } from './meetingQueryKeys'
  * 약속을 삭제하고 관련 쿼리 캐시를 무효화합니다.
  * - 약속 승인 리스트 캐시 무효화
  * - 약속 승인 카운트 캐시 무효화
+ * - 모임 약속 리스트 캐시 무효화
+ * - 내 약속 탭 카운트 캐시 무효화
+ * - 내 약속 목록 캐시 무효화
  *
  * @example
  * const deleteMutation = useDeleteMeeting()
@@ -34,7 +38,12 @@ export const useDeleteMeeting = (gatheringId: number) => {
       queryClient.invalidateQueries({
         queryKey: meetingQueryKeys.approvals(),
       })
+      // 모임 약속 리스트 캐시 무효화
       queryClient.invalidateQueries({ queryKey: gatheringQueryKeys.meetings(gatheringId) })
+      // 내 약속 탭 카운트 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: myMeetingQueryKeys.tabCounts() })
+      // 내 약속 목록 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: myMeetingQueryKeys.lists() })
     },
   })
 }

--- a/src/features/meetings/hooks/useJoinMeeting.ts
+++ b/src/features/meetings/hooks/useJoinMeeting.ts
@@ -10,6 +10,7 @@ import type { ApiResponse } from '@/api/types'
 import { joinMeeting } from '@/features/meetings'
 
 import { meetingQueryKeys } from './meetingQueryKeys'
+import { myMeetingQueryKeys } from './myMeetingQueryKeys'
 
 /**
  * 약속 참가신청 mutation 훅
@@ -17,6 +18,8 @@ import { meetingQueryKeys } from './meetingQueryKeys'
  * @description
  * 약속에 참가신청하고 관련 쿼리 캐시를 무효화합니다.
  * - 약속 상세 캐시 무효화
+ * - 내 약속 탭 카운트 캐시 무효화
+ * - 내 약속 목록 캐시 무효화
  *
  */
 export const useJoinMeeting = () => {
@@ -28,6 +31,14 @@ export const useJoinMeeting = () => {
       // 약속 상세 캐시 무효화
       queryClient.invalidateQueries({
         queryKey: meetingQueryKeys.detail(variables),
+      })
+      // 내 약속 탭 카운트 캐시 무효화
+      queryClient.invalidateQueries({
+        queryKey: myMeetingQueryKeys.tabCounts(),
+      })
+      // 내 약속 목록 캐시 무효화
+      queryClient.invalidateQueries({
+        queryKey: myMeetingQueryKeys.lists(),
       })
     },
   })


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

약속 참가 신청 후 홈 화면에서 내 약속 탭 카운트가 갱신되지 않는 버그를 수정했습니다.

## 🔧 변경 사항

- `useJoinMeeting` mutation `onSuccess` 시 내 약속 탭 카운트 캐시 무효화 추가 (`myMeetingQueryKeys.tabCounts()`)
- `useJoinMeeting` mutation `onSuccess` 시 내 약속 목록 캐시 무효화 추가 (`myMeetingQueryKeys.lists()`)

## 📸 스크린샷 (선택 사항)

N/A

## 📄 기타

Closes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 약속 참석, 참석 취소, 승인 처리, 삭제 시 '내 약속' 목록과 탭 카운트가 일관되게 갱신되도록 동기화 개선되었습니다.
  * 위 작업들이 관련된 상세 보기·승인·모임 목록 등 화면 데이터도 함께 최신 상태로 유지되도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->