### PR TITLE
fix: 약속 종료 후 개인회고 버튼 비활성화 및 잘못된 이동 수정 (#121)

### DIFF
--- a/src/pages/Home/components/HomeMeetingCard.tsx
+++ b/src/pages/Home/components/HomeMeetingCard.tsx
@@ -60,7 +60,9 @@ export default function HomeMeetingCard({ meeting }: HomeMeetingCardProps) {
     if (isUpcoming && preOpinionTemplateConfirmed) {
       navigate(ROUTES.PRE_OPINIONS(gatheringId, meetingId))
     }
-    // TODO: 종료 → 개인 회고 작성 페이지 연결
+    if (isDone) {
+      navigate(ROUTES.PERSONAL_RETROSPECTIVE(gatheringId, meetingId))
+    }
   }
 
   return (
@@ -123,8 +125,7 @@ export default function HomeMeetingCard({ meeting }: HomeMeetingCardProps) {
         </Button>
       )}
       {isDone && (
-        // TODO: 개인 회고 작성 페이지 연결 후 disabled 제거
-        <Button variant="primary" size="small" className="shrink-0" disabled>
+        <Button variant="primary" size="small" className="shrink-0" onClick={handleActionClick}>
           개인 회고 작성하기
         </Button>
       )}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

홈 화면에서 종료된 약속의 "개인 회고 작성하기" 버튼이 항상 비활성화 상태였고, 버튼 클릭 시 개인회고 작성 페이지가 아닌 약속 상세 페이지로 이동되던 버그를 수정했습니다.

## 🔧 변경 사항

- `HomeMeetingCard`: isDone 버튼의 `disabled` 하드코딩 제거
- `HomeMeetingCard`: handleActionClick에 DONE 케이스 추가 → `ROUTES.PERSONAL_RETROSPECTIVE`로 이동

## 📸 스크린샷 (선택 사항)

<img width="1289" height="456" alt="스크린샷 2026-04-16 오후 11 43 30" src="https://github.com/user-attachments/assets/0c913684-3d4c-472f-9d36-a393b858c612" />


## 📄 기타

Closes #121