### PR TITLE
fix: 멤버 관리에서 모임장 항목에 삭제 버튼 노출 (#123)

### DIFF
--- a/src/pages/Gatherings/GatheringSettingPage.tsx
+++ b/src/pages/Gatherings/GatheringSettingPage.tsx
@@ -297,7 +297,7 @@ export default function GatheringSettingPage() {
                             <MemberCard
                               key={member.gatheringMemberId}
                               member={member}
-                              actions={['remove']}
+                              actions={member.role === 'LEADER' ? [] : ['remove']}
                               onAction={handleMemberAction}
                               disabled={removeMemberMutation.isPending}
                             />


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

모임 설정 페이지의 멤버 관리(승인 완료 탭)에서 모임장(`role === 'LEADER'`) 항목에도 삭제 버튼이 노출되는 버그를 수정했습니다.

## 🔧 변경 사항

- `GatheringSettingPage`의 ACTIVE 멤버 목록 렌더링 시 `member.role === 'LEADER'`인 경우 `actions={[]}`로 처리하여 삭제 버튼 숨김

## 📸 스크린샷 (선택 사항)

<img width="1135" height="902" alt="스크린샷 2026-04-17 오후 10 12 56" src="https://github.com/user-attachments/assets/1dd5d5e1-b691-44a9-9b98-6ee23069e460" />


## 📄 기타

Closes #123