### PR TITLE
fix: 모임 상세 멤버 표시 UI 오류 및 아바타 UX 개선 (#125)

### DIFF
--- a/src/features/gatherings/components/GatheringDetailInfo.tsx
+++ b/src/features/gatherings/components/GatheringDetailInfo.tsx
@@ -44,7 +44,7 @@ export default function GatheringDetailInfo({
           {leader && (
             <div className="flex items-center gap-2">
               <span className="text-grey-600 typo-body2 font-semibold">모임장</span>
-              <Avatar variant="leader" size="sm">
+              <Avatar variant="leader" size="sm" title={leader.nickname}>
                 <AvatarImage src={leader.profileImageUrl ?? undefined} alt={leader.nickname} />
                 <AvatarFallback>{leader.nickname.slice(0, 1)}</AvatarFallback>
               </Avatar>
@@ -53,33 +53,36 @@ export default function GatheringDetailInfo({
 
           {/* 멤버 아바타 그룹 (멤버가 있을 때만) */}
           {otherMembers.length > 0 && (
-            <AvatarGroup>
-              {visibleMembers.map((member) => (
-                <Avatar key={member.gatheringMemberId} size="sm">
-                  <AvatarImage src={member.profileImageUrl ?? undefined} alt={member.nickname} />
-                  <AvatarFallback>{member.nickname.slice(0, 1)}</AvatarFallback>
-                </Avatar>
-              ))}
-              {remainingCount > 0 && (
-                <AvatarGroupCount
-                  items={otherMembers.slice(MAX_VISIBLE_MEMBERS).map((m) => ({
-                    id: String(m.gatheringMemberId),
-                    name: m.nickname,
-                    src: m.profileImageUrl ?? undefined,
-                  }))}
-                  preview={
-                    otherMembers[MAX_VISIBLE_MEMBERS]
-                      ? {
-                          name: otherMembers[MAX_VISIBLE_MEMBERS].nickname,
-                          src: otherMembers[MAX_VISIBLE_MEMBERS].profileImageUrl ?? undefined,
-                        }
-                      : undefined
-                  }
-                >
-                  +{remainingCount}
-                </AvatarGroupCount>
-              )}
-            </AvatarGroup>
+            <div className="flex items-center gap-2">
+              <span className="text-grey-600 typo-body2 font-semibold">멤버</span>
+              <AvatarGroup>
+                {visibleMembers.map((member) => (
+                  <Avatar key={member.gatheringMemberId} size="sm" title={member.nickname}>
+                    <AvatarImage src={member.profileImageUrl ?? undefined} alt={member.nickname} />
+                    <AvatarFallback>{member.nickname.slice(0, 1)}</AvatarFallback>
+                  </Avatar>
+                ))}
+                {remainingCount > 0 && (
+                  <AvatarGroupCount
+                    items={otherMembers.slice(MAX_VISIBLE_MEMBERS).map((m) => ({
+                      id: String(m.gatheringMemberId),
+                      name: m.nickname,
+                      src: m.profileImageUrl ?? undefined,
+                    }))}
+                    preview={
+                      otherMembers[MAX_VISIBLE_MEMBERS]
+                        ? {
+                            name: otherMembers[MAX_VISIBLE_MEMBERS].nickname,
+                            src: otherMembers[MAX_VISIBLE_MEMBERS].profileImageUrl ?? undefined,
+                          }
+                        : undefined
+                    }
+                  >
+                    +{remainingCount}
+                  </AvatarGroupCount>
+                )}
+              </AvatarGroup>
+            </div>
           )}
         </div>
       </div>

--- a/src/features/meetings/components/MeetingDetailInfo.tsx
+++ b/src/features/meetings/components/MeetingDetailInfo.tsx
@@ -64,7 +64,7 @@ export default function MeetingDetailInfo({ meeting }: MeetingDetailInfoProps) {
             {leader && (
               <div className="flex items-center gap-small">
                 <p>약속장</p>
-                <Avatar variant="host">
+                <Avatar variant="host" title={leader.nickname}>
                   <AvatarImage src={leader.profileImageUrl} alt={leader.nickname} />
                   <AvatarFallback>{leader.nickname[0]}</AvatarFallback>
                 </Avatar>
@@ -77,7 +77,7 @@ export default function MeetingDetailInfo({ meeting }: MeetingDetailInfoProps) {
                 <p>멤버</p>
                 <AvatarGroup>
                   {displayedMembers.map((member) => (
-                    <Avatar key={member.userId}>
+                    <Avatar key={member.userId} title={member.nickname}>
                       <AvatarImage src={member.profileImageUrl} alt={member.nickname} />
                       <AvatarFallback>{member.nickname[0]}</AvatarFallback>
                     </Avatar>

--- a/src/pages/Gatherings/GatheringSettingPage.tsx
+++ b/src/pages/Gatherings/GatheringSettingPage.tsx
@@ -297,7 +297,7 @@ export default function GatheringSettingPage() {
                             <MemberCard
                               key={member.gatheringMemberId}
                               member={member}
-                              actions={['remove']}
+                              actions={member.role === 'LEADER' ? [] : ['remove']}
                               onAction={handleMemberAction}
                               disabled={removeMemberMutation.isPending}
                             />

--- a/src/shared/ui/Avatar.tsx
+++ b/src/shared/ui/Avatar.tsx
@@ -316,9 +316,9 @@ function AvatarGroupCount({
           align="start"
           sideOffset={8}
           className={cn(
-            'z-50 min-w-40 rounded-small bg-grey-800 p-base text-white',
+            'z-50 min-w-40 rounded-small bg-grey-800/95 backdrop-blur-sm p-base text-white',
             'data-[state=open]:animate-in data-[state=closed]:animate-out',
-            'max-h-32 overflow-auto custom-scroll-dark'
+            'max-h-36 overflow-auto custom-scroll-dark'
           )}
         >
           <ul className="flex flex-col gap-small">


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

모임/약속 상세 페이지의 아바타 관련 UI 버그를 수정하고 UX를 개선했습니다.

## 🔧 변경 사항

- `GatheringDetailInfo`: 멤버 아바타 그룹 앞에 누락된 "멤버" 텍스트 레이블 추가
- `GatheringDetailInfo`, `MeetingDetailInfo`: 모임장/약속장/멤버 아바타에 `title` 속성 추가하여 호버 시 닉네임 표시
- `AvatarGroupCount` HoverCard: 피그마 디자인에 맞게 `backdrop-blur` 스타일 개선

## 📸 스크린샷 (선택 사항)

<img width="398" height="275" alt="image" src="https://github.com/user-attachments/assets/608302d8-f588-4a91-bd7b-1b3cbb58ad2e" />


## 📄 기타

Closes #125

관련 Notion 이슈:
- MEET-300 UI: 모임의 멤버 표시 UI 오류
- MEET-300 UX: 모임 구성원 확인 페이지 부재로 인한 UX 개선 제안

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 아바타에 닉네임 정보 표시 추가
  * 모임 멤버 섹션에 라벨 추가
  * 리더 역할 멤버의 작업 권한 제한

* **스타일**
  * 아바타 호버 영역의 배경 투명도 및 블러 효과 개선
  * 아바타 목록 최대 높이 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->