### PR TITLE
fix: 멤버 입장에서 약속 만들기 버튼 미노출 (#127)

### DIFF
--- a/src/features/gatherings/components/GatheringMeetingSection.tsx
+++ b/src/features/gatherings/components/GatheringMeetingSection.tsx
@@ -139,28 +139,30 @@ export default function GatheringMeetingSection({
           </Tabs>
         </div>
 
-        {/* 버튼들 (모임장만) */}
-        {isLeader && (
-          <div className="flex items-center gap-xsmall">
+        {/* 버튼들 */}
+        <div className="flex items-center gap-xsmall">
+          {/* 약속 설정: 모임장만 */}
+          {isLeader && (
             <Button variant="secondary" outline size="small" onClick={handleMeetingSettings}>
               약속 설정
             </Button>
-            {showCreateTooltip ? (
-              <Tooltip dismissable onOpenChange={(open) => !open && setShowCreateTooltip(false)}>
-                <TooltipTrigger asChild>
-                  <Button size="small" onClick={handleCreateMeeting}>
-                    약속 만들기
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>약속을 만들어 함께 책을 읽어보세요!</TooltipContent>
-              </Tooltip>
-            ) : (
-              <Button size="small" onClick={handleCreateMeeting}>
-                약속 만들기
-              </Button>
-            )}
-          </div>
-        )}
+          )}
+          {/* 약속 만들기: 모든 멤버 */}
+          {showCreateTooltip ? (
+            <Tooltip dismissable onOpenChange={(open) => !open && setShowCreateTooltip(false)}>
+              <TooltipTrigger asChild>
+                <Button size="small" onClick={handleCreateMeeting}>
+                  약속 만들기
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>약속을 만들어 함께 책을 읽어보세요!</TooltipContent>
+            </Tooltip>
+          ) : (
+            <Button size="small" onClick={handleCreateMeeting}>
+              약속 만들기
+            </Button>
+          )}
+        </div>
       </div>
 
       {/* 약속 목록 */}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

모임 멤버가 모임 상세 페이지에서 [약속 만들기] 버튼을 볼 수 없던 버그를 수정했습니다.

## 🔧 변경 사항

- `GatheringMeetingSection`에서 [약속 만들기] 버튼이 `isLeader` 조건으로 묶여 모임장에게만 노출되던 문제 수정
- [약속 설정] 버튼은 모임장(`LEADER`)에게만, [약속 만들기] 버튼은 모든 멤버(`LEADER` + `MEMBER`)에게 노출되도록 분리

## 📸 스크린샷 (선택 사항)

N/A

## 📄 기타

Closes #127
관련 노션 이슈: https://www.notion.so/33cd0cee0cba807eb36ed4e0fde2f6cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 약속 생성 버튼이 모든 사용자에게 표시되도록 수정되었습니다. (기존: 리더만 표시)
  * 약속 설정은 여전히 리더에게만 제한되어 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->