### PR TITLE
fix: 모임 약속 카드 버튼 조건부 표시 및 네비게이션 구현 (#129)

### DIFF
--- a/src/features/gatherings/components/GatheringMeetingCard.tsx
+++ b/src/features/gatherings/components/GatheringMeetingCard.tsx
@@ -24,7 +24,15 @@ export default function GatheringMeetingCard({
 }: GatheringMeetingCardProps) {
   const navigate = useNavigate()
 
-  const { meetingId, meetingName, bookName, startDateTime, endDateTime, hasPreOpinion, hasPersonalRetrospective } = meeting
+  const {
+    meetingId,
+    meetingName,
+    bookName,
+    startDateTime,
+    endDateTime,
+    hasPreOpinion,
+    hasPersonalRetrospective,
+  } = meeting
 
   const status = getMeetingDisplayStatus(startDateTime, endDateTime)
   const ddayText = getDdayText(startDateTime, endDateTime)

--- a/src/features/gatherings/components/GatheringMeetingCard.tsx
+++ b/src/features/gatherings/components/GatheringMeetingCard.tsx
@@ -160,10 +160,6 @@ export default function GatheringMeetingCard({
           </button>
         )}
 
-        {showPreAnswer && (showMeetingReview || showPersonalReview) && (
-          <div className="w-px h-12 bg-grey-300" />
-        )}
-
         {showMeetingReview && (
           <button
             type="button"

--- a/src/features/gatherings/components/GatheringMeetingCard.tsx
+++ b/src/features/gatherings/components/GatheringMeetingCard.tsx
@@ -31,28 +31,36 @@ export default function GatheringMeetingCard({
   const formattedDate = formatToDateTimeRange(startDateTime, endDateTime)
 
   const isOngoing = status === 'IN_PROGRESS'
+  const isUpcoming = status === 'UPCOMING'
+  const isDone = status === 'DONE'
+
+  const showPreAnswer = isUpcoming && meeting.meetingStatus === 'CONFIRMED'
+  const showMeetingReview = isDone
+  const showPersonalReview = isDone
 
   const handleClick = () => {
     navigate(ROUTES.MEETING_DETAIL(gatheringId, meetingId))
   }
 
-  // 사전답변, 약속회고, 개인회고 버튼 핸들러
+  // TODO: 백엔드 API에 preOpinionSubmitted 필드 추가 후
+  // preOpinionSubmitted ? PRE_OPINIONS(조회) : PRE_OPINION_WRITE(작성) 으로 분기
   const handlePreAnswerClick = (e: React.MouseEvent) => {
     e.stopPropagation()
-    // TODO: 사전답변 작성/조회 페이지로 이동
-    console.log('사전답변 클릭')
+    navigate(ROUTES.PRE_OPINIONS(gatheringId, meetingId))
   }
 
+  // TODO: 백엔드 API에 retrospectiveStatus 필드 추가 후
+  // RetrospectiveCardButtons와 동일하게 상태별 라우트 분기 적용
   const handleMeetingReviewClick = (e: React.MouseEvent) => {
     e.stopPropagation()
-    // TODO: 약속회고 페이지로 이동
-    console.log('약속회고 클릭')
+    navigate(ROUTES.MEETING_RETROSPECTIVE_CREATE(gatheringId, meetingId))
   }
 
+  // TODO: 백엔드 API에 personalRetrospectiveWritten 필드 추가 후
+  // personalRetrospectiveWritten ? PERSONAL_RETROSPECTIVE_VIEW(조회) : PERSONAL_RETROSPECTIVE(작성) 으로 분기
   const handlePersonalReviewClick = (e: React.MouseEvent) => {
     e.stopPropagation()
-    // TODO: 개인회고 작성/조회 페이지로 이동
-    console.log('개인회고 클릭')
+    navigate(ROUTES.PERSONAL_RETROSPECTIVE(gatheringId, meetingId))
   }
 
   // 약속 중 카드 (빨간 배경)
@@ -90,7 +98,6 @@ export default function GatheringMeetingCard({
   }
 
   // 예정/종료 카드
-  const isUpcoming = status === 'UPCOMING'
   const statusLabel = isUpcoming ? '예정' : '종료'
   const badgeColor = isUpcoming ? 'yellow' : 'grey'
   const ddayColor = isUpcoming ? 'text-yellow-300' : 'text-grey-600'
@@ -132,39 +139,44 @@ export default function GatheringMeetingCard({
 
       {/* 우측: 사전답변, 약속회고, 개인회고 버튼 */}
       <div className="flex items-center gap-base">
-        {/* 사전답변 */}
-        <button
-          type="button"
-          className="flex flex-col items-center gap-xtiny p-tiny w-16 rounded-tiny cursor-pointer hover:bg-grey-100"
-          onClick={handlePreAnswerClick}
-        >
-          <FileQuestion className="size-5 text-grey-600" />
-          <span className="typo-body5 font-semibold text-grey-600">사전답변</span>
-        </button>
+        {showPreAnswer && (
+          <button
+            type="button"
+            className="flex flex-col items-center gap-xtiny p-tiny w-16 rounded-tiny cursor-pointer hover:bg-grey-100"
+            onClick={handlePreAnswerClick}
+          >
+            <FileQuestion className="size-5 text-grey-600" />
+            <span className="typo-body5 font-semibold text-grey-600">사전답변</span>
+          </button>
+        )}
 
-        <div className="w-px h-12 bg-grey-300" />
+        {showPreAnswer && (showMeetingReview || showPersonalReview) && (
+          <div className="w-px h-12 bg-grey-300" />
+        )}
 
-        {/* 약속회고 */}
-        <button
-          type="button"
-          className="flex flex-col items-center gap-xtiny p-tiny w-16 rounded-tiny cursor-pointer hover:bg-grey-100"
-          onClick={handleMeetingReviewClick}
-        >
-          <BarChart3 className="size-5 text-grey-600" />
-          <span className="typo-body5 font-semibold text-grey-600">약속회고</span>
-        </button>
+        {showMeetingReview && (
+          <button
+            type="button"
+            className="flex flex-col items-center gap-xtiny p-tiny w-16 rounded-tiny cursor-pointer hover:bg-grey-100"
+            onClick={handleMeetingReviewClick}
+          >
+            <BarChart3 className="size-5 text-grey-600" />
+            <span className="typo-body5 font-semibold text-grey-600">약속회고</span>
+          </button>
+        )}
 
-        <div className="w-px h-12 bg-grey-300" />
+        {showMeetingReview && showPersonalReview && <div className="w-px h-12 bg-grey-300" />}
 
-        {/* 개인회고 */}
-        <button
-          type="button"
-          className="flex flex-col items-center gap-xtiny p-tiny w-16 rounded-tiny cursor-pointer hover:bg-grey-100"
-          onClick={handlePersonalReviewClick}
-        >
-          <NotebookPen className="size-5 text-grey-600" />
-          <span className="typo-body5 font-semibold text-grey-600">개인회고</span>
-        </button>
+        {showPersonalReview && (
+          <button
+            type="button"
+            className="flex flex-col items-center gap-xtiny p-tiny w-16 rounded-tiny cursor-pointer hover:bg-grey-100"
+            onClick={handlePersonalReviewClick}
+          >
+            <NotebookPen className="size-5 text-grey-600" />
+            <span className="typo-body5 font-semibold text-grey-600">개인회고</span>
+          </button>
+        )}
       </div>
     </div>
   )

--- a/src/features/gatherings/components/GatheringMeetingCard.tsx
+++ b/src/features/gatherings/components/GatheringMeetingCard.tsx
@@ -24,7 +24,7 @@ export default function GatheringMeetingCard({
 }: GatheringMeetingCardProps) {
   const navigate = useNavigate()
 
-  const { meetingId, meetingName, bookName, startDateTime, endDateTime } = meeting
+  const { meetingId, meetingName, bookName, startDateTime, endDateTime, hasPreOpinion, hasPersonalRetrospective } = meeting
 
   const status = getMeetingDisplayStatus(startDateTime, endDateTime)
   const ddayText = getDdayText(startDateTime, endDateTime)
@@ -42,25 +42,27 @@ export default function GatheringMeetingCard({
     navigate(ROUTES.MEETING_DETAIL(gatheringId, meetingId))
   }
 
-  // TODO: 백엔드 API에 preOpinionSubmitted 필드 추가 후
-  // preOpinionSubmitted ? PRE_OPINIONS(조회) : PRE_OPINION_WRITE(작성) 으로 분기
   const handlePreAnswerClick = (e: React.MouseEvent) => {
     e.stopPropagation()
-    navigate(ROUTES.PRE_OPINIONS(gatheringId, meetingId))
+    navigate(
+      hasPreOpinion
+        ? ROUTES.PRE_OPINIONS(gatheringId, meetingId)
+        : ROUTES.PRE_OPINION_WRITE(gatheringId, meetingId)
+    )
   }
 
-  // TODO: 백엔드 API에 retrospectiveStatus 필드 추가 후
-  // RetrospectiveCardButtons와 동일하게 상태별 라우트 분기 적용
   const handleMeetingReviewClick = (e: React.MouseEvent) => {
     e.stopPropagation()
     navigate(ROUTES.MEETING_RETROSPECTIVE_CREATE(gatheringId, meetingId))
   }
 
-  // TODO: 백엔드 API에 personalRetrospectiveWritten 필드 추가 후
-  // personalRetrospectiveWritten ? PERSONAL_RETROSPECTIVE_VIEW(조회) : PERSONAL_RETROSPECTIVE(작성) 으로 분기
   const handlePersonalReviewClick = (e: React.MouseEvent) => {
     e.stopPropagation()
-    navigate(ROUTES.PERSONAL_RETROSPECTIVE(gatheringId, meetingId))
+    navigate(
+      hasPersonalRetrospective
+        ? ROUTES.PERSONAL_RETROSPECTIVE_VIEW(gatheringId, meetingId)
+        : ROUTES.PERSONAL_RETROSPECTIVE(gatheringId, meetingId)
+    )
   }
 
   // 약속 중 카드 (빨간 배경)

--- a/src/features/gatherings/gatherings.types.ts
+++ b/src/features/gatherings/gatherings.types.ts
@@ -165,6 +165,10 @@ export interface GatheringMeetingItem {
   endDateTime: string
   /** 약속 상태 */
   meetingStatus: MeetingStatus
+  /** 사전답변 제출 여부 */
+  hasPreOpinion: boolean
+  /** 개인 회고 작성 여부 */
+  hasPersonalRetrospective: boolean
 }
 
 /** 모임 약속 목록 응답 (페이지 기반) */


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

모임 상세 화면의 약속 카드(`GatheringMeetingCard`)에서 사전답변·약속회고·개인회고 버튼이 약속 상태와 무관하게 항상 표시되고, 클릭 시 `console.log`만 출력되던 미구현 상태를 수정했습니다.

## 🔧 변경 사항

- **사전답변 버튼**: UPCOMING + CONFIRMED 약속에만 표시, 클릭 시 `PRE_OPINIONS` 페이지로 이동
- **약속회고 버튼**: DONE 약속에만 표시, 클릭 시 `MEETING_RETROSPECTIVE_CREATE` 페이지로 이동
- **개인회고 버튼**: DONE 약속에만 표시, 클릭 시 `PERSONAL_RETROSPECTIVE` 페이지로 이동
- **구분선**: 인접 버튼이 모두 표시될 때만 렌더링
- 백엔드 API 필드(`preOpinionSubmitted`, `personalRetrospectiveWritten`, `retrospectiveStatus`) 추가 후 작성/조회 분기가 필요한 부분에 TODO 주석 추가

## 📸 스크린샷 (선택 사항)

N/A

## 📄 기타

Closes #129
관련 노션 이슈: https://www.notion.so/33cd0cee0cba80f49d30c4cd35a34156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 회의 카드의 액션 버튼이 회의 상태와 사용자 제출 여부에 따라 동적으로 표시됩니다.
  * 사전 의견 및 개인 회고의 제출 상태에 따른 네비게이션이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->