### PR TITLE
fix: 약속 생성/확정 후 모임 책장 캐시 무효화 누락 (#131)

### DIFF
--- a/src/features/meetings/hooks/useConfirmMeeting.ts
+++ b/src/features/meetings/hooks/useConfirmMeeting.ts
@@ -46,6 +46,8 @@ export const useConfirmMeeting = (gatheringId: number) => {
       queryClient.invalidateQueries({ queryKey: myMeetingQueryKeys.tabCounts() })
       // 내 약속 목록 캐시 무효화
       queryClient.invalidateQueries({ queryKey: myMeetingQueryKeys.lists() })
+      // 모임 책장 캐시 무효화 (약속 확정 시 책이 모임 책장에 반영됨)
+      queryClient.invalidateQueries({ queryKey: gatheringQueryKeys.books(gatheringId) })
     },
   })
 }

--- a/src/features/meetings/hooks/useCreateMeeting.ts
+++ b/src/features/meetings/hooks/useCreateMeeting.ts
@@ -7,6 +7,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { ApiError } from '@/api/errors'
 import type { ApiResponse } from '@/api/types'
+import { gatheringQueryKeys } from '@/features/gatherings'
 import {
   createMeeting,
   type CreateMeetingRequest,
@@ -26,10 +27,14 @@ export const useCreateMeeting = () => {
 
   return useMutation<ApiResponse<CreateMeetingResponse>, ApiError, CreateMeetingRequest>({
     mutationFn: (data: CreateMeetingRequest) => createMeeting(data),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       // 약속 승인 관련 모든 캐시 무효화
       queryClient.invalidateQueries({
         queryKey: meetingQueryKeys.approvals(),
+      })
+      // 모임 책장 캐시 무효화 (약속 생성 시 책이 모임 책장에 추가됨)
+      queryClient.invalidateQueries({
+        queryKey: gatheringQueryKeys.books(variables.gatheringId),
       })
     },
   })


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

약속 생성(`useCreateMeeting`) 및 약속 확정(`useConfirmMeeting`) 후 모임 책장 쿼리 캐시가 무효화되지 않아, TanStack Query staleTime(5분) 내 재방문 시 빈 책장이 표시되는 버그를 수정합니다.

## 🔧 변경 사항

- `useCreateMeeting.onSuccess`: `gatheringQueryKeys.books(variables.gatheringId)` 캐시 무효화 추가
- `useConfirmMeeting.onSuccess`: `gatheringQueryKeys.books(gatheringId)` 캐시 무효화 추가

## 📸 스크린샷 (선택 사항)

N/A

## 📄 기타

- 관련 이슈: Closes #131
- 노션 QA: https://www.notion.so/33cd0cee0cba80f6bf82eb96dbe9200b
- 모임 책장 API(`GET /api/gatherings/{gatheringId}/books`) 자체가 빈 응답을 반환하는 백엔드 이슈도 별도 확인 필요