### PR TITLE
fix: stt 실패 시 약속 회고 결과 페이지 크래시 및 상태 표시 오류 (#135)

### DIFF
--- a/src/features/retrospectives/meeting/components/SummaryInfoBanner.tsx
+++ b/src/features/retrospectives/meeting/components/SummaryInfoBanner.tsx
@@ -1,13 +1,28 @@
 type SummaryInfoBannerProps = {
   message?: string
+  variant?: 'success' | 'error'
 }
 
 export default function SummaryInfoBanner({
-  message = 'AI 요약이 완료되었어요. 확인 후 자유롭게 수정해 보세요.',
+  message,
+  variant = 'success',
 }: SummaryInfoBannerProps) {
+  const defaultMessage =
+    variant === 'error'
+      ? 'AI 요약에 실패했어요. 수정하기를 눌러 직접 내용을 입력해 보세요.'
+      : 'AI 요약이 완료되었어요. 확인 후 자유롭게 수정해 보세요.'
+
+  const isError = variant === 'error'
+
   return (
-    <div className="w-full rounded-small bg-primary-100 border border-primary-200 px-base py-small">
-      <p className="typo-caption1 text-primary-400">{message}</p>
+    <div
+      className={`w-full rounded-small border px-base py-small ${
+        isError ? 'bg-accent-100 border-accent-200' : 'bg-primary-100 border-primary-200'
+      }`}
+    >
+      <p className={`typo-caption1 ${isError ? 'text-accent-300' : 'text-primary-400'}`}>
+        {message ?? defaultMessage}
+      </p>
     </div>
   )
 }

--- a/src/features/retrospectives/meeting/components/TopicSummaryCard.tsx
+++ b/src/features/retrospectives/meeting/components/TopicSummaryCard.tsx
@@ -94,7 +94,7 @@ export default function TopicSummaryCard({
             <h5 className="typo-subtitle2 text-black">핵심요약</h5>
             {isEditing ? (
               <Textarea
-                value={displaySummary}
+                value={displaySummary ?? ''}
                 onChange={(e) => onSummaryChange?.(e.target.value)}
                 height={80}
               />
@@ -176,7 +176,7 @@ export default function TopicSummaryCard({
                 </button>
               </div>
             ) : (
-              keyPoints.map((kp, kpIndex) => (
+              (keyPoints ?? []).map((kp, kpIndex) => (
                 <div key={kpIndex} className="flex flex-col gap-xtiny">
                   <p className="typo-subtitle5 text-black">
                     {kpIndex + 1}. {kp.title}

--- a/src/features/retrospectives/meeting/retrospectives.types.ts
+++ b/src/features/retrospectives/meeting/retrospectives.types.ts
@@ -102,8 +102,8 @@ export interface SummaryTopic {
   confirmOrder: number
   topicTitle: string
   topicDescription: string
-  summary: string
-  keyPoints: KeyPoint[]
+  summary: string | null
+  keyPoints: KeyPoint[] | null
 }
 
 /** 회고 요약 응답 (GET, PATCH, POST publish 공통) */

--- a/src/pages/Retrospectives/meeting/MeetingRetrospectiveCreatePage.tsx
+++ b/src/pages/Retrospectives/meeting/MeetingRetrospectiveCreatePage.tsx
@@ -82,9 +82,10 @@ export default function MeetingRetrospectiveCreatePage() {
     sttMutation.mutate(
       { gatheringId, meetingId, file: uploadedFile ?? undefined },
       {
-        onSuccess: () => {
+        onSuccess: (data) => {
+          // AI 요약 실패해서 data.status가 DONE이 아니어도 결과 페이지로 우선 이동
           navigate(ROUTES.MEETING_RETROSPECTIVE(gatheringId, meetingId), {
-            state: { fromAiSummary: true },
+            state: { fromAiSummary: true, aiSuccess: data.status === 'DONE' },
           })
         },
         onError: (err) => {

--- a/src/pages/Retrospectives/meeting/MeetingRetrospectiveResultPage.tsx
+++ b/src/pages/Retrospectives/meeting/MeetingRetrospectiveResultPage.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/shared/ui'
 
 type LocationState = {
   fromAiSummary?: boolean
+  aiSuccess?: boolean
 }
 
 type EditableSummaryTopic = Omit<SummaryTopic, 'keyPoints'> & { keyPoints: EditableKeyPoint[] }
@@ -43,14 +44,19 @@ export default function MeetingRetrospectiveResultPage() {
   const [editedTopics, setEditedTopics] = useState<EditableSummaryTopic[]>([])
 
   // CreatePage에서 AI 요약 완료 후 도착했을 때 토스트 표시
-  const fromAiSummary = (location.state as LocationState)?.fromAiSummary ?? false
+  const [fromAiSummary] = useState(() => (location.state as LocationState)?.fromAiSummary ?? false)
+  const [aiSuccess] = useState(() => (location.state as LocationState)?.aiSuccess ?? true)
 
   useEffect(() => {
     if (fromAiSummary) {
       navigate(location.pathname, { replace: true, state: null })
-      showToast('독서 모임 내용 요약이 완료됐어요')
+      if (aiSuccess) {
+        showToast('독서 모임 내용 요약이 완료됐어요')
+      } else {
+        showErrorToast('AI 요약에 실패했습니다. 직접 수정하여 완성해주세요.')
+      }
     }
-  }, [fromAiSummary, navigate, location.pathname])
+  }, [fromAiSummary, aiSuccess, navigate, location.pathname])
 
   // ─── 유효성 검사 (모든 hook 호출 이후) ───
   if (!gatheringId || !meetingId || !Number.isInteger(mId) || mId <= 0) return null
@@ -63,7 +69,7 @@ export default function MeetingRetrospectiveResultPage() {
     setEditedTopics(
       summaryData.topics.map((topic) => ({
         ...topic,
-        keyPoints: topic.keyPoints.map((kp) => ({
+        keyPoints: (topic.keyPoints ?? []).map((kp) => ({
           ...kp,
           id: crypto.randomUUID(),
           details: kp.details.map((d) => ({ id: crypto.randomUUID(), value: d })),
@@ -80,7 +86,7 @@ export default function MeetingRetrospectiveResultPage() {
         data: {
           topics: editedTopics.map((t) => ({
             topicId: t.topicId,
-            summary: t.summary,
+            summary: t.summary ?? '',
             keyPoints: t.keyPoints.map((kp) => ({
               title: kp.title,
               details: kp.details.map((d) => d.value),
@@ -174,7 +180,9 @@ export default function MeetingRetrospectiveResultPage() {
       {/* 회고 콘텐츠 영역 */}
       <div className="mx-auto max-w-layout-max px-layout-padding mt-base flex flex-col gap-medium pb-xlarge">
         {/* 안내 배너 (미발행 + 보기 모드일 때) */}
-        {summaryData && !summaryData.isPublished && !isEditing && <SummaryInfoBanner />}
+        {summaryData && !summaryData.isPublished && !isEditing && (
+          <SummaryInfoBanner variant={aiSuccess ? 'success' : 'error'} />
+        )}
 
         {/* 토픽 카드 */}
         {isLoading ? (
@@ -192,7 +200,7 @@ export default function MeetingRetrospectiveResultPage() {
               key={topic.topicId}
               topic={topic}
               isEditing={isEditing}
-              editedSummary={isEditing ? editedTopics[index]?.summary : undefined}
+              editedSummary={isEditing ? (editedTopics[index]?.summary ?? undefined) : undefined}
               editedKeyPoints={isEditing ? editedTopics[index]?.keyPoints : undefined}
               onSummaryChange={(v) => handleSummaryChange(index, v)}
               onKeyPointsChange={(kps) => handleKeyPointsChange(index, kps)}

--- a/src/pages/Retrospectives/meeting/MeetingRetrospectiveResultPage.tsx
+++ b/src/pages/Retrospectives/meeting/MeetingRetrospectiveResultPage.tsx
@@ -180,8 +180,9 @@ export default function MeetingRetrospectiveResultPage() {
       {/* 회고 콘텐츠 영역 */}
       <div className="mx-auto max-w-layout-max px-layout-padding mt-base flex flex-col gap-medium pb-xlarge">
         {/* 안내 배너 (미발행 + 보기 모드일 때) */}
-        {summaryData && !summaryData.isPublished && !isEditing && (
-          <SummaryInfoBanner variant={aiSuccess ? 'success' : 'error'} />
+        {!isEditing && !aiSuccess && <SummaryInfoBanner variant="error" />}
+        {!isEditing && aiSuccess && summaryData && !summaryData.isPublished && (
+          <SummaryInfoBanner variant="success" />
         )}
 
         {/* 토픽 카드 */}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

STT Job이 `FAILED` 상태로 반환될 때 `MeetingRetrospectiveResultPage`에서 크래시가 발생하던 문제를
우선 AI 요약 실패해도 직접 편집하여 플로우를 진행할 수 있도록 수정하였습니다.

## 🔧 변경 사항

- `SummaryTopic` 타입의 `summary`, `keyPoints` 필드를 `null` 허용으로 수정 (STT 실패 시 API가 null 반환)
- `TopicSummaryCard`: `keyPoints?.map()` → `(keyPoints ?? []).map()` 으로 null 크래시 방지
- `TopicSummaryCard`: `Textarea` value에 `?? ''` 처리로 타입 에러 수정
- `MeetingRetrospectiveCreatePage`: STT 응답 status가 `DONE`이 아닌 경우도 결과 페이지로 이동하되 `aiSuccess: false` 전달
- `MeetingRetrospectiveResultPage`: STT 실패 시 에러 토스트 표시 + 에러 배너 렌더링
- `MeetingRetrospectiveResultPage`: `aiSuccess`를 `useState` lazy initializer로 마운트 시점에 고정하여 `navigate(state: null)` 이후 리렌더에서 값이 초기화되는 문제 해결
- `SummaryInfoBanner`: `variant` prop 추가 (`'success'` / `'error'`), 에러 시 accent 컬러 배너 표시

## 📸 스크린샷 (선택 사항)

<img width="1161" height="653" alt="스크린샷 2026-04-22 오후 11 54 33" src="https://github.com/user-attachments/assets/ade83a06-d1c0-402d-a910-ab6a850553a9" />


## 📄 기타

Closes #135