### PR TITLE
fix: 홈 책 상태 필터 및 배지 표시 (#137)

### DIFF
--- a/src/features/book/book.mock.ts
+++ b/src/features/book/book.mock.ts
@@ -43,6 +43,7 @@ const mockBookListItems: BookListItem[] = [
     publisher: '곰 출판',
     authors: '룰루 밀러',
     bookReadingStatus: 'READING',
+    meetingProgressStatus: 'BEFORE',
     thumbnail: 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9791189327156.jpg',
     rating: 0.5,
     gatherings: [
@@ -56,6 +57,7 @@ const mockBookListItems: BookListItem[] = [
     publisher: '민음사',
     authors: '헤르만 헤세',
     bookReadingStatus: 'READING',
+    meetingProgressStatus: 'AFTER',
     thumbnail: 'https://contents.kyobobook.co.kr/sih/fit-in/458x0/pdt/9788937460449.jpg',
     rating: 4.5,
     gatherings: [{ gatheringId: 2, gatheringName: '주말 독서 모임' }],
@@ -66,6 +68,7 @@ const mockBookListItems: BookListItem[] = [
     publisher: '민음사',
     authors: '조지 오웰',
     bookReadingStatus: 'COMPLETED',
+    meetingProgressStatus: null,
     thumbnail:
       'https://i.namu.wiki/i/OuId9i6YhTdBIk5XDIZWVre8GtdOv_OaaXSL_WlGUvPisTnbN2jwn0lf_b8sJp_bjBLoKgl6Fa4-enbgZJIRLA.webp',
     rating: 5,
@@ -462,13 +465,27 @@ export const getMockBooks = async (params: GetBooksParams = {}): Promise<GetBook
 // ============================================================
 
 function filterMockBooks(params: GetBooksParams): GetBooksResponse {
-  const { readingStatus, minRating, maxRating, sortBy = 'TIME', sortOrder = 'DESC' } = params
+  const {
+    readingStatus,
+    minRating,
+    maxRating,
+    meetingProgressStatus,
+    sortBy = 'TIME',
+    sortOrder = 'DESC',
+  } = params
 
   let filteredItems = [...mockBookListItems]
 
   // 상태 필터
   if (readingStatus) {
     filteredItems = filteredItems.filter((item) => item.bookReadingStatus === readingStatus)
+  }
+
+  // 약속 진행 상태 필터
+  if (meetingProgressStatus) {
+    filteredItems = filteredItems.filter(
+      (item) => item.meetingProgressStatus === meetingProgressStatus
+    )
   }
 
   // 별점 범위 필터
@@ -509,7 +526,7 @@ function filterMockBooks(params: GetBooksParams): GetBooksResponse {
       pending: pendingCount,
       total: mockBookListItems.length,
     },
-    totalCount: mockBookListItems.length,
+    totalCount: filteredItems.length,
   }
 }
 

--- a/src/features/book/book.types.ts
+++ b/src/features/book/book.types.ts
@@ -8,6 +8,9 @@ import type { CursorPaginatedResponse } from '@/api/types'
 /** 책 읽기 상태 */
 export type BookReadingStatus = 'READING' | 'COMPLETED' | 'PENDING'
 
+/** 책과 연결된 약속 진행 상태 */
+export type BookMeetingProgressStatus = 'BEFORE' | 'AFTER'
+
 /** 책 목록 정렬 기준 */
 export type BookSortBy = 'TIME' | 'RATING'
 
@@ -42,6 +45,7 @@ export interface BookListItem {
   publisher: string
   authors: string
   bookReadingStatus: BookReadingStatus
+  meetingProgressStatus: BookMeetingProgressStatus | null
   thumbnail: string
   rating: number | null
   gatherings: BookListGathering[]
@@ -52,6 +56,7 @@ export interface GetBooksParams {
   readingStatus?: BookReadingStatus
   minRating?: number
   maxRating?: number
+  meetingProgressStatus?: BookMeetingProgressStatus
   sortBy?: BookSortBy
   sortOrder?: BookSortOrder
   cursorRating?: number

--- a/src/features/book/index.ts
+++ b/src/features/book/index.ts
@@ -18,3 +18,4 @@ export {
   ReviewHistoryCard,
 } from './components'
 export * from './hooks'
+export * from './lib'

--- a/src/features/book/lib/index.ts
+++ b/src/features/book/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './meetingProgressStatus'

--- a/src/features/book/lib/meetingProgressStatus.ts
+++ b/src/features/book/lib/meetingProgressStatus.ts
@@ -1,0 +1,15 @@
+import type { BookMeetingProgressStatus } from '@/features/book/book.types'
+import type { BadgeProps } from '@/shared/ui'
+
+export const MEETING_PROGRESS_STATUS_LABEL: Record<BookMeetingProgressStatus, string> = {
+  BEFORE: '약속 전',
+  AFTER: '약속 후',
+}
+
+export const MEETING_PROGRESS_STATUS_BADGE_COLOR: Record<
+  BookMeetingProgressStatus,
+  BadgeProps['color']
+> = {
+  BEFORE: 'yellow',
+  AFTER: 'grey',
+}

--- a/src/pages/Home/components/HomeBookCard.tsx
+++ b/src/pages/Home/components/HomeBookCard.tsx
@@ -1,25 +1,44 @@
 import { Link } from 'react-router-dom'
 
+import type { BookMeetingProgressStatus } from '@/features/book'
+import { MEETING_PROGRESS_STATUS_BADGE_COLOR, MEETING_PROGRESS_STATUS_LABEL } from '@/features/book'
 import { ROUTES } from '@/shared/constants'
+import { Badge } from '@/shared/ui'
 
 interface HomeBookCardProps {
   bookId: number
   title: string
   authors: string
   thumbnail: string
+  meetingProgressStatus: BookMeetingProgressStatus | null
 }
 
-export default function HomeBookCard({ bookId, title, authors, thumbnail }: HomeBookCardProps) {
+export default function HomeBookCard({
+  bookId,
+  title,
+  authors,
+  thumbnail,
+  meetingProgressStatus,
+}: HomeBookCardProps) {
   return (
     <Link to={ROUTES.BOOK_DETAIL(bookId)} className="block w-45 shrink-0">
       {/* 썸네일 */}
-      <div className="h-65 w-45 overflow-hidden rounded-small bg-grey-200">
+      <div className="relative h-65 w-45 overflow-hidden rounded-small bg-grey-200">
         <img
           src={thumbnail}
           alt={`${title} 표지`}
           className="h-full w-full object-cover"
           loading="lazy"
         />
+        {meetingProgressStatus && (
+          <Badge
+            color={MEETING_PROGRESS_STATUS_BADGE_COLOR[meetingProgressStatus]}
+            size="small"
+            className="absolute top-2 left-2"
+          >
+            {MEETING_PROGRESS_STATUS_LABEL[meetingProgressStatus]}
+          </Badge>
+        )}
       </div>
 
       {/* 책 정보 */}

--- a/src/pages/Home/components/ReadingBooksSection.tsx
+++ b/src/pages/Home/components/ReadingBooksSection.tsx
@@ -14,17 +14,34 @@ import HomeSectionHeader from './HomeSectionHeader'
 type BookTab = 'all' | 'pre' | 'post'
 
 export default function ReadingBooksSection() {
-  // TODO: pre/post 탭 활성화 시 activeTab을 useBooks filter 파라미터로 연결 필요
   const [activeTab, setActiveTab] = useState<BookTab>('all')
   const [isSearchModalOpen, setIsSearchModalOpen] = useState(false)
   const { mutateAsync: createBook, isPending: isCreating } = useCreateBook()
   const { openConfirm } = useGlobalModalStore()
 
-  const { data, isLoading } = useBooks({ readingStatus: 'READING' })
+  const allBooksQuery = useBooks({ readingStatus: 'READING' })
+  const beforeBooksQuery = useBooks({
+    readingStatus: 'READING',
+    meetingProgressStatus: 'BEFORE',
+  })
+  const afterBooksQuery = useBooks({
+    readingStatus: 'READING',
+    meetingProgressStatus: 'AFTER',
+  })
+  const activeQuery = {
+    all: allBooksQuery,
+    pre: beforeBooksQuery,
+    post: afterBooksQuery,
+  }[activeTab]
+
+  const { data, isLoading } = activeQuery
   const showSkeleton = useDeferredLoading(isLoading)
 
   const books = data?.pages.flatMap((page) => page.items) ?? []
-  const totalCount = data?.pages[0]?.statusCounts.reading ?? 0
+  const totalCount = allBooksQuery.data?.pages[0]?.statusCounts.reading ?? 0
+  const beforeCount = beforeBooksQuery.data?.pages[0]?.totalCount ?? 0
+  const afterCount = afterBooksQuery.data?.pages[0]?.totalCount ?? 0
+  const isFilteredEmpty = activeTab !== 'all'
 
   return (
     <section className="flex flex-col gap-medium">
@@ -38,10 +55,10 @@ export default function ReadingBooksSection() {
             <TabsTrigger value="all" badge={totalCount}>
               전체
             </TabsTrigger>
-            <TabsTrigger value="pre" badge={0} disabled>
+            <TabsTrigger value="pre" badge={beforeCount}>
               약속 전
             </TabsTrigger>
-            <TabsTrigger value="post" badge={0} disabled>
+            <TabsTrigger value="post" badge={afterCount}>
               약속 후
             </TabsTrigger>
           </TabsList>
@@ -63,19 +80,27 @@ export default function ReadingBooksSection() {
       ) : books.length === 0 ? (
         <div className="flex h-85 flex-col items-center justify-center gap-medium rounded-base border border-grey-300">
           <div className="flex flex-col items-center gap-xtiny">
-            <p className="text-grey-600 typo-subtitle2">내 책장이 비어있어요.</p>
+            <p className="text-grey-600 typo-subtitle2">
+              {isFilteredEmpty
+                ? `${activeTab === 'pre' ? '약속 전' : '약속 후'} 상태인 책이 없어요.`
+                : '내 책장이 비어있어요.'}
+            </p>
             <p className="text-grey-600 typo-body3">
-              첫 번째 책을 등록하고 독서 기록을 시작해 보세요!
+              {isFilteredEmpty
+                ? '다른 상태의 책을 확인해 보세요.'
+                : '첫 번째 책을 등록하고 독서 기록을 시작해 보세요!'}
             </p>
           </div>
-          <Button
-            variant="secondary"
-            outline
-            size="small"
-            onClick={() => setIsSearchModalOpen(true)}
-          >
-            책 추가하기
-          </Button>
+          {!isFilteredEmpty && (
+            <Button
+              variant="secondary"
+              outline
+              size="small"
+              onClick={() => setIsSearchModalOpen(true)}
+            >
+              책 추가하기
+            </Button>
+          )}
         </div>
       ) : (
         <BookCarousel>
@@ -86,6 +111,7 @@ export default function ReadingBooksSection() {
               title={book.title}
               authors={book.authors}
               thumbnail={book.thumbnail}
+              meetingProgressStatus={book.meetingProgressStatus}
             />
           ))}
         </BookCarousel>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

홈 화면의 지금 읽고 있는 책 섹션에서 약속 진행 상태를 확인하고 필터링할 수 있도록 GET /api/book 변경사항을 반영했습니다.

## 🔧 변경 사항

- 책 목록 타입에 meetingProgressStatus 응답 필드와 필터 파라미터 추가
- 홈 화면 책 탭에 전체/약속 전/약속 후 필터 연결
- 홈 책 카드에 약속 전/약속 후 상태 배지 표시
- mock 책 목록에 meetingProgressStatus 필터 동작 반영

## 📸 스크린샷 (선택 사항)

<img width="1130" height="552" alt="image" src="https://github.com/user-attachments/assets/748276c3-0a37-4190-9c38-0496152b6d3f" />


## 📄 기타

Closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 도서의 모임 진행 상태(약속 전/약속 후) 시각적 배지 표시 추가
  * 모임 진행 상태별 도서 필터링 기능 추가

* **개선사항**
  * 필터 적용 시 맞춤형 빈 상태 메시지 제공
  * 탭 배지에 필터링된 정확한 도서 수 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->