### PR TITLE
fix: 닉네임 변경 완료 토스트 표시 (#139)

### DIFF
--- a/src/features/user/components/MyPageDropdown.tsx
+++ b/src/features/user/components/MyPageDropdown.tsx
@@ -1,4 +1,5 @@
 import { useLogout } from '@/features/auth'
+import { showToast } from '@/shared/lib/toast'
 import { Button, TextButton } from '@/shared/ui'
 import { useGlobalModalStore } from '@/store'
 
@@ -55,7 +56,10 @@ export function MyPageDropdown({ onClose }: MyPageDropdownProps) {
     if (!canSave) return
 
     updateNickname(nickname, {
-      onSuccess: () => onClose?.(),
+      onSuccess: () => {
+        showToast('닉네임이 변경되었어요')
+        onClose?.()
+      },
     })
   }
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

마이페이지에서 닉네임을 변경·저장하면 실제로는 변경되지만 **완료 토스트가 표시되지 않아** 사용자가 변경 성공 여부를 알 수 없는 문제를 수정합니다.

`MyPageDropdown.handleSave`의 닉네임 저장 성공 콜백에서 `showToast`로 완료 안내를 노출합니다.

Closes #139

## 🔧 변경 사항

- `src/features/user/components/MyPageDropdown.tsx`
  - `showToast` import 추가
  - `updateNickname` 성공 시 `showToast('닉네임이 변경되었어요')` 호출 후 드롭다운 닫기

## 📸 스크린샷 (선택 사항)

<img width="1258" height="894" alt="image" src="https://github.com/user-attachments/assets/2c9b3176-09f8-49cd-bfbb-fe6628c570c6" />


## 📄 기타

- 닉네임 변경·저장 시 토스트 `"닉네임이 변경되었어요"` 노출 확인(sonner DOM + 인사말 갱신).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 닉네임을 성공적으로 변경한 후 확인 메시지가 화면에 표시됩니다. 이를 통해 변경 작업이 완료되었음을 명확하게 인지할 수 있으며, 사용자 경험이 더욱 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->