### PR TITLE
fix: 모임 가입 중복 신청 시 안내 메시지 처리 (#140)

### DIFF
--- a/src/pages/Gatherings/InvitePage.tsx
+++ b/src/pages/Gatherings/InvitePage.tsx
@@ -61,10 +61,20 @@ export default function InvitePage() {
         }
       },
       onError: (error) => {
-        if (error instanceof ApiError && error.is(ErrorCode.ALREADY_GATHERING_MEMBER)) {
-          openAlert('이미 가입된 모임', '이미 가입된 모임입니다.')
-          navigate(ROUTES.GATHERINGS)
-          return
+        if (error instanceof ApiError) {
+          if (error.is(ErrorCode.ALREADY_GATHERING_MEMBER)) {
+            openAlert('이미 가입된 모임', '이미 가입된 모임입니다.')
+            navigate(ROUTES.GATHERINGS)
+            return
+          }
+          if (error.is(ErrorCode.JOIN_REQUEST_ALREADY_PENDING)) {
+            openAlert(
+              '가입 신청 완료',
+              '이미 가입 요청이 진행 중이에요. 모임장의 승인을 기다려주세요.'
+            )
+            navigate(ROUTES.GATHERINGS)
+            return
+          }
         }
         openError('오류', '가입 신청 중 오류가 발생했습니다.')
       },


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

초대 링크로 모임 가입을 신청(PENDING)한 뒤 다시 신청하면, 서버는 `409 GA009`("이미 가입 요청이 진행 중입니다.")를 정확히 내려주지만 화면에는 **generic "오류 / 가입 신청 중 오류가 발생했습니다."** 모달만 노출되던 문제를 수정합니다.

`InvitePage`의 `onError`에서 `JOIN_REQUEST_ALREADY_PENDING(GA009)`를 분기 처리하여 명확한 안내 후 모임 목록으로 이동합니다.

Closes #140

## 🔧 변경 사항

- `src/pages/Gatherings/InvitePage.tsx`
  - `onError`에서 `ApiError` 분기 정리
  - `JOIN_REQUEST_ALREADY_PENDING(GA009)` 시 `openAlert('가입 신청 완료', '이미 가입 요청이 진행 중이에요. 모임장의 승인을 기다려주세요.')` + `navigate(ROUTES.GATHERINGS)`
  - (`GA009` 코드/메시지는 `src/api/errors.ts`에 이미 존재)

## 📸 스크린샷 (선택 사항)

<img width="686" height="416" alt="image" src="https://github.com/user-attachments/assets/7196b689-e074-48ba-84d1-12b0960547be" />
