### PR TITLE
fix: 미참가 약속 사전답변 버튼 노출 차단 (#141)

### DIFF
--- a/src/features/gatherings/components/GatheringMeetingCard.tsx
+++ b/src/features/gatherings/components/GatheringMeetingCard.tsx
@@ -30,6 +30,8 @@ export default function GatheringMeetingCard({
     bookName,
     startDateTime,
     endDateTime,
+    meetingStatus,
+    joined,
     hasPreOpinion,
     hasPersonalRetrospective,
   } = meeting
@@ -42,7 +44,8 @@ export default function GatheringMeetingCard({
   const isUpcoming = status === 'UPCOMING'
   const isDone = status === 'DONE'
 
-  const showPreAnswer = isUpcoming && meeting.meetingStatus === 'CONFIRMED'
+  // 참여한 약속에만 사전답변 노출 (미참여자가 클릭 시 사전의견 페이지에서 튕기는 문제 방지)
+  const showPreAnswer = isUpcoming && meetingStatus === 'CONFIRMED' && joined
   const showMeetingReview = isDone
   const showPersonalReview = isDone
 

--- a/src/features/gatherings/gatherings.types.ts
+++ b/src/features/gatherings/gatherings.types.ts
@@ -1,5 +1,6 @@
 import type { CursorPaginatedResponse, PaginatedResponse } from '@/api'
-import type { MeetingStatus } from '@/features/meetings'
+import type { MeetingStatus, MyMeetingRole } from '@/features/meetings'
+import type { TopicType } from '@/features/topics/topics.types'
 
 /** 모임 기본 정보 (공통) */
 export interface GatheringBase {
@@ -163,6 +164,12 @@ export interface GatheringMeetingItem {
   startDateTime: string
   /** 종료 일시 (ISO 8601) */
   endDateTime: string
+  /** 주제 유형 목록 */
+  topicTypes: TopicType[]
+  /** 현재 사용자의 약속 참여 여부 */
+  joined: boolean
+  /** 현재 사용자의 약속 내 역할 */
+  myRole: MyMeetingRole
   /** 약속 상태 */
   meetingStatus: MeetingStatus
   /** 사전답변 제출 여부 */


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

모임 약속 리스트에서 **참여하지 않은(joined=false)** 예정·확정 약속에도 "사전답변" 버튼이 노출되고, 클릭 시 사전의견 작성 페이지에서 권한 오류로 이전 화면으로 튕기던 문제를 수정합니다.

서버는 약속 리스트 응답에 이미 `joined`/`myRole`를 내려주고 있어, FE가 이를 사용해 참여한 약속에만 버튼을 노출하도록 게이트를 추가합니다.

Closes #141

## 🔧 변경 사항

- `src/features/gatherings/gatherings.types.ts`
  - `GatheringMeetingItem`을 약속 리스트 응답 계약에 맞춰 보강: `topicTypes`, `joined`, `myRole` 추가 (`MyMeetingRole`, `TopicType` 재사용)
- `src/features/gatherings/components/GatheringMeetingCard.tsx`
  - `meetingStatus`/`joined`를 구조분해로 일관되게 사용
  - `showPreAnswer = isUpcoming && meetingStatus === 'CONFIRMED' && joined` 로 참여 게이트 추가

## 📸 스크린샷 (선택 사항)

- 미참가(joined=false): 사전답변 버튼 **미노출**
- 참가(joined=true): 사전답변 버튼 **노출** + 클릭 시 사전의견 작성 페이지 정상 진입(튕김 없음)