### PR TITLE
[feat] 약속 확정(승인) API 에러코드 추가

### DIFF
--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -113,6 +113,7 @@ export const ErrorCode = {
   MEETING_DELETE_NOT_ALLOWED: 'M015',
   MEETING_JOIN_TIME_EXPIRED: 'M016',
   MEETING_UPDATE_TIME_EXPIRED: 'M017',
+  MEETING_CONFIRM_TIME_CONFLICT: 'M024',
 
   // Topic
   TOPIC_NOT_FOUND: 'E101',
@@ -258,6 +259,8 @@ export const ErrorMessage: Record<ErrorCodeType, string> = {
   [ErrorCode.MEETING_DELETE_NOT_ALLOWED]: '약속 시작 24시간 이내에는 삭제할 수 없습니다.',
   [ErrorCode.MEETING_JOIN_TIME_EXPIRED]: '약속 시작 24시간 이내에는 참가 신청할 수 없습니다.',
   [ErrorCode.MEETING_UPDATE_TIME_EXPIRED]: '약속 시작 24시간 이내에는 수정할 수 없습니다.',
+  [ErrorCode.MEETING_CONFIRM_TIME_CONFLICT]:
+    '모임 내 같은 시간대에 이미 확정된 약속이 있어 승인할 수 없습니다.',
 
   // Topic
   [ErrorCode.TOPIC_NOT_FOUND]: '주제를 찾을 수 없습니다.',


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
약속 확정(승인) API 에러코드추가

## 🔧 변경 사항

아래 에러코드 추가
- 코드: M024 (MEETING_CONFIRM_TIME_CONFLICT)
- 메시지: "모임 내 같은 시간대에 이미 확정된 약속이 있어 승인할 수 없습니다."
- status: 400

## 📸 스크린샷 (선택 사항)

<img width="1184" height="475" alt="image" src="https://github.com/user-attachments/assets/9bdc082f-5ddf-489c-bae1-778c4dde82dc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 약속 확인 시 동일 시간대에 이미 확정된 약속이 있는 경우에 대한 오류 처리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->