### PR TITLE
fix: 홈 사전의견/개인회고 완료 후 작성하기 버튼 처리 (#148)

### DIFF
--- a/src/features/meetings/meetings.types.ts
+++ b/src/features/meetings/meetings.types.ts
@@ -291,6 +291,8 @@ export interface MyMeetingListItem {
   myRole: MyMeetingRole
   progressStatus: MyMeetingProgressStatus
   preOpinionTemplateConfirmed: boolean
+  hasPreOpinion: boolean
+  hasPersonalRetrospective: boolean
 }
 
 /** 메인페이지 내 약속 커서 */

--- a/src/features/pre-opinion/hooks/useSubmitPreOpinion.ts
+++ b/src/features/pre-opinion/hooks/useSubmitPreOpinion.ts
@@ -6,6 +6,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import type { ApiError } from '@/api'
+import { myMeetingQueryKeys } from '@/features/meetings/hooks/myMeetingQueryKeys'
 import { topicQueryKeys } from '@/features/topics/hooks/topicQueryKeys'
 
 import { submitPreOpinion } from '../preOpinion.api'
@@ -37,6 +38,8 @@ export function useSubmitPreOpinion({ gatheringId, meetingId }: GetPreOpinionPar
         // confirmed 전체 무효화: 제출 후 어떤 gatheringId/meetingId 조합이 영향 받는지
         // 특정할 수 없으므로 confirmed 범위 전체를 무효화합니다.
         queryClient.invalidateQueries({ queryKey: topicQueryKeys.confirmed() }),
+        // 홈 '내 약속' 카드의 사전의견 제출여부(hasPreOpinion) 갱신
+        queryClient.invalidateQueries({ queryKey: myMeetingQueryKeys.all }),
       ])
     },
   })

--- a/src/features/retrospectives/personal/hooks/useSavePersonalRetrospective.ts
+++ b/src/features/retrospectives/personal/hooks/useSavePersonalRetrospective.ts
@@ -3,9 +3,10 @@
  * @description 개인 회고 저장 mutation 훅
  */
 
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { ApiError } from '@/api/errors'
+import { myMeetingQueryKeys } from '@/features/meetings/hooks/myMeetingQueryKeys'
 
 import { savePersonalRetrospective } from '../personalRetrospective.api'
 import type { SavePersonalRetrospectiveParams } from '../personalRetrospective.types'
@@ -23,7 +24,13 @@ import type { SavePersonalRetrospectiveParams } from '../personalRetrospective.t
  * ```
  */
 export function useSavePersonalRetrospective() {
+  const queryClient = useQueryClient()
+
   return useMutation<void, ApiError, SavePersonalRetrospectiveParams>({
     mutationFn: (params) => savePersonalRetrospective(params),
+    onSuccess: () => {
+      // 홈 '내 약속' 카드의 개인회고 작성여부(hasPersonalRetrospective) 갱신
+      queryClient.invalidateQueries({ queryKey: myMeetingQueryKeys.all })
+    },
   })
 }

--- a/src/pages/Home/components/HomeMeetingCard.tsx
+++ b/src/pages/Home/components/HomeMeetingCard.tsx
@@ -42,6 +42,8 @@ export default function HomeMeetingCard({ meeting }: HomeMeetingCardProps) {
     myRole,
     progressStatus,
     preOpinionTemplateConfirmed,
+    hasPreOpinion,
+    hasPersonalRetrospective,
   } = meeting
 
   const status = STATUS_CONFIG[progressStatus]
@@ -58,10 +60,20 @@ export default function HomeMeetingCard({ meeting }: HomeMeetingCardProps) {
   const handleActionClick = (e: MouseEvent) => {
     e.stopPropagation()
     if (isUpcoming && preOpinionTemplateConfirmed) {
-      navigate(ROUTES.PRE_OPINION_WRITE(gatheringId, meetingId))
+      // 이미 제출한 경우 작성 페이지가 아닌 조회 페이지로 이동
+      navigate(
+        hasPreOpinion
+          ? ROUTES.PRE_OPINIONS(gatheringId, meetingId)
+          : ROUTES.PRE_OPINION_WRITE(gatheringId, meetingId)
+      )
     }
     if (isDone) {
-      navigate(ROUTES.PERSONAL_RETROSPECTIVE(gatheringId, meetingId))
+      // 이미 작성한 경우 작성 페이지가 아닌 조회 페이지로 이동
+      navigate(
+        hasPersonalRetrospective
+          ? ROUTES.PERSONAL_RETROSPECTIVE_VIEW(gatheringId, meetingId)
+          : ROUTES.PERSONAL_RETROSPECTIVE(gatheringId, meetingId)
+      )
     }
   }
 
@@ -121,12 +133,12 @@ export default function HomeMeetingCard({ meeting }: HomeMeetingCardProps) {
           disabled={!preOpinionTemplateConfirmed}
           onClick={handleActionClick}
         >
-          사전 의견 작성하기
+          {hasPreOpinion ? '사전 의견 보기' : '사전 의견 작성하기'}
         </Button>
       )}
       {isDone && (
         <Button variant="primary" size="small" className="shrink-0" onClick={handleActionClick}>
-          개인 회고 작성하기
+          {hasPersonalRetrospective ? '개인 회고 보기' : '개인 회고 작성하기'}
         </Button>
       )}
     </div>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

홈 '내 약속' 카드에서 **사전의견을 작성·공유**하거나 **개인회고를 작성 완료**한 뒤에도 "작성하기" 버튼이 계속 노출되고, 클릭 시 작성 페이지로 다시 이동하던 문제를 수정합니다.

서버 응답의 본인 완료여부(`hasPreOpinion`/`hasPersonalRetrospective`)를 사용해, 완료된 경우 '보기' 라벨 + 조회 페이지로 이동하도록 분기합니다. (모임 상세 카드 `GatheringMeetingCard`와 동일 패턴)

Closes #148

## 🔧 변경 사항

- `src/features/meetings/meetings.types.ts`
  - `MyMeetingListItem`에 `hasPreOpinion`, `hasPersonalRetrospective` 추가
- `src/pages/Home/components/HomeMeetingCard.tsx`
  - 사전의견: `hasPreOpinion ? '사전 의견 보기' + PRE_OPINIONS : '사전 의견 작성하기' + PRE_OPINION_WRITE`
  - 개인회고: `hasPersonalRetrospective ? '개인 회고 보기' + PERSONAL_RETROSPECTIVE_VIEW : '개인 회고 작성하기' + PERSONAL_RETROSPECTIVE`
- `src/features/pre-opinion/hooks/useSubmitPreOpinion.ts`, `src/features/retrospectives/personal/hooks/useSavePersonalRetrospective.ts`
  - 완료 성공 시 홈 내 약속 쿼리(`myMeetingQueryKeys`) 무효화

## 📄 기타

- ⚠️ **BE 선행 의존:** `GET /api/meetings/me` 응답(`MyMeetingListItemResponse`)에 `hasPreOpinion`, `hasPersonalRetrospective` 추가 필요(백엔드 담당자에게 별도 전달). 두 값 모두 모임 약속 리스트 빌더(`buildMeetingItems`)가 이미 계산 중. BE 배포 전에는 필드 부재 시 현행 동작으로 graceful degrade되어 회귀 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 약속 리스트에서 사전의견 및 개인회고 작성 여부를 확인할 수 있습니다.
  * 약속 카드의 액션 버튼이 작성 상태에 따라 "작성하기" 또는 "보기"로 동적으로 변경됩니다.
  * 사전의견이나 개인회고 제출 후 메인페이지가 자동으로 최신 상태로 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->