### PR TITLE
[fix] 2차 QA 관련 수정 (책, 사전의견)

### DIFF
--- a/src/features/book/book.api.ts
+++ b/src/features/book/book.api.ts
@@ -182,7 +182,7 @@ export async function getMyGatherings(
  *
  * @example
  * ```typescript
- * const timeline = await getBookTimeline(1, { sort: 'LATEST' })
+ * const timeline = await getBookTimeline(1, { sort: 'DESC' })
  * ```
  */
 export async function getBookTimeline(

--- a/src/features/book/book.mock.ts
+++ b/src/features/book/book.mock.ts
@@ -537,7 +537,7 @@ function filterMockTimeline(
   const {
     gatheringId,
     recordType,
-    sort = 'LATEST',
+    sort = 'DESC',
     pageSize = 10,
     cursorEventAt,
     cursorSourceId,
@@ -570,7 +570,7 @@ function filterMockTimeline(
   }
 
   // 정렬
-  const sortMultiplier = sort === 'LATEST' ? -1 : 1
+  const sortMultiplier = sort === 'DESC' ? -1 : 1
   filtered.sort(
     (a, b) => sortMultiplier * (new Date(a.eventAt).getTime() - new Date(b.eventAt).getTime())
   )

--- a/src/features/book/book.types.ts
+++ b/src/features/book/book.types.ts
@@ -145,7 +145,7 @@ export type GetGatheringsResponse = CursorPaginatedResponse<Gathering, string>
 export type RecordType = 'MEMO' | 'QUOTE'
 
 /** 정렬 방식 */
-export type RecordSortType = 'LATEST' | 'OLDEST'
+export type RecordSortType = 'DESC' | 'ASC'
 
 /** 개인 회고 메타 정보 */
 export interface PersonalRecordMeta {

--- a/src/features/book/components/BookList.tsx
+++ b/src/features/book/components/BookList.tsx
@@ -77,7 +77,11 @@ function BookList({
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } = useBooks({
     readingStatus: status,
     minRating: selectedRating?.min,
-    maxRating: selectedRating?.max,
+    // 0.5점 단위 별점(예: 3.5)도 함께 조회되도록 max 구간을 .9까지 확장
+    maxRating:
+      selectedRating?.max !== undefined
+        ? Math.round((selectedRating.max + 0.9) * 10) / 10
+        : undefined,
     sortBy: 'TIME',
     sortOrder,
   })

--- a/src/features/book/components/BookLogList.tsx
+++ b/src/features/book/components/BookLogList.tsx
@@ -33,7 +33,7 @@ const BookLogList = ({ personalBookId, isRecording }: BookLogListProps) => {
   const [selectedGathering, setSelectedGathering] = useState('')
   const [recordType, setRecordType] = useState<RecordType | ''>('')
   const [openDropdown, setOpenDropdown] = useState<OpenDropdown>(null)
-  const [sortType, setSortType] = useState<RecordSortType>('LATEST')
+  const [sortType, setSortType] = useState<RecordSortType>('DESC')
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [modalMode, setModalMode] = useState<'create' | 'edit'>('create')
   const [editingRecord, setEditingRecord] = useState<PersonalRecord | null>(null)
@@ -154,11 +154,11 @@ const BookLogList = ({ personalBookId, isRecording }: BookLogListProps) => {
             </div>
             <Tabs value={sortType} onValueChange={(v) => setSortType(v as RecordSortType)}>
               <TabsList size="small" className="gap-0">
-                <TabsTrigger value="LATEST" size="small">
+                <TabsTrigger value="DESC" size="small">
                   최신순
                 </TabsTrigger>
                 <span className="typo-caption1 text-grey-600 px-xsmall">·</span>
-                <TabsTrigger value="OLDEST" size="small">
+                <TabsTrigger value="ASC" size="small">
                   오래된순
                 </TabsTrigger>
               </TabsList>

--- a/src/features/book/components/BookLogList.tsx
+++ b/src/features/book/components/BookLogList.tsx
@@ -109,7 +109,7 @@ const BookLogList = ({ personalBookId, isRecording }: BookLogListProps) => {
         <div className="mx-auto max-w-layout-max px-layout-padding py-base">
           <div className="flex justify-between mb-base">
             <h2 className="typo-heading2 text-grey-800">감상 기록</h2>
-            <Button onClick={handleCreateRecord}>기록 추가하기</Button>
+            {isRecording && <Button onClick={handleCreateRecord}>기록 추가하기</Button>}
           </div>
           <div className="flex justify-between">
             <div className="flex flex-wrap gap-xsmall">

--- a/src/features/book/components/MeetingGroupRecordItem.tsx
+++ b/src/features/book/components/MeetingGroupRecordItem.tsx
@@ -44,8 +44,12 @@ const MeetingGroupRecordItem = ({ record }: MeetingGroupRecordItemProps) => {
               {/* 생각 변화 */}
               {topic.changedThoughts && (
                 <div className="flex flex-col gap-small">
-                  <p className="typo-body1 text-grey-700">{topic.changedThoughts.keyIssue}</p>
-                  <p className="typo-body1 text-black">{topic.changedThoughts.postOpinion}</p>
+                  <p className="typo-body1 text-grey-700 whitespace-pre-wrap">
+                    {topic.changedThoughts.keyIssue}
+                  </p>
+                  <p className="typo-body1 text-black whitespace-pre-wrap">
+                    {topic.changedThoughts.postOpinion}
+                  </p>
                 </div>
               )}
             </div>
@@ -56,10 +60,14 @@ const MeetingGroupRecordItem = ({ record }: MeetingGroupRecordItemProps) => {
                 {topic.othersPerspectives.map((perspective) => (
                   <div key={perspective.meetingMemberId} className="flex flex-col gap-medium">
                     <ExcerptBlock>
-                      <p className="typo-subtitle5 text-grey-800">{perspective.opinionContent}</p>
+                      <p className="typo-subtitle5 text-grey-800 whitespace-pre-wrap">
+                        {perspective.opinionContent}
+                      </p>
                       <span className="typo-body1 text-grey-600">{perspective.memberNickname}</span>
                     </ExcerptBlock>
-                    <p className="typo-body1 text-grey-800">{perspective.impressiveReason}</p>
+                    <p className="typo-body1 text-grey-800 whitespace-pre-wrap">
+                      {perspective.impressiveReason}
+                    </p>
                   </div>
                 ))}
               </div>
@@ -72,8 +80,8 @@ const MeetingGroupRecordItem = ({ record }: MeetingGroupRecordItemProps) => {
           <div key={`free-${idx}`} className="flex flex-col">
             {(topicGroups.length > 0 || idx > 0) && <Division className="mt-medium mb-large" />}
             <div className="flex flex-col gap-small">
-              <h5 className="typo-subtitle2 text-grey-800">{text.title}</h5>
-              <p className="typo-body1 text-black">{text.content}</p>
+              <h5 className="typo-subtitle2 text-grey-800 whitespace-pre-wrap">{text.title}</h5>
+              <p className="typo-body1 text-black whitespace-pre-wrap">{text.content}</p>
             </div>
           </div>
         ))}

--- a/src/features/book/components/MeetingPreOpinionItem.tsx
+++ b/src/features/book/components/MeetingPreOpinionItem.tsx
@@ -43,9 +43,13 @@ const MeetingPreOpinionItem = ({ record, onEdit, onDelete }: MeetingPreOpinionIt
               <h4 className="typo-subtitle2 text-grey-800">
                 주제 {topic.confirmOrder}. {topic.topicTitle}
               </h4>
-              <p className="mt-xxtiny typo-body1 text-grey-700">{topic.topicDescription}</p>
+              <p className="mt-xxtiny typo-body1 text-grey-700 whitespace-pre-wrap">
+                {topic.topicDescription}
+              </p>
             </div>
-            {topic.answer && <p className="typo-body1 text-black">{topic.answer}</p>}
+            {topic.answer && (
+              <p className="typo-body1 text-black whitespace-pre-wrap">{topic.answer}</p>
+            )}
           </div>
           {idx !== sortedTopics.length - 1 && <Division className="mt-medium" />}
         </div>

--- a/src/features/book/components/MeetingRetrospectiveItem.tsx
+++ b/src/features/book/components/MeetingRetrospectiveItem.tsx
@@ -52,8 +52,12 @@ const MeetingRetrospectiveItem = ({ record, onEdit, onDelete }: MeetingRetrospec
               {/* 생각 변화 */}
               {topic.changedThoughts && (
                 <div className="flex flex-col gap-small">
-                  <p className="typo-body1 text-grey-700">{topic.changedThoughts.keyIssue}</p>
-                  <p className="typo-body1 text-black">{topic.changedThoughts.postOpinion}</p>
+                  <p className="typo-body1 text-grey-700 whitespace-pre-wrap">
+                    {topic.changedThoughts.keyIssue}
+                  </p>
+                  <p className="typo-body1 text-black whitespace-pre-wrap">
+                    {topic.changedThoughts.postOpinion}
+                  </p>
                 </div>
               )}
             </div>
@@ -67,7 +71,9 @@ const MeetingRetrospectiveItem = ({ record, onEdit, onDelete }: MeetingRetrospec
                       <p className="typo-subtitle5 text-grey-800">{perspective.opinionContent}</p>
                       <span className="typo-body1 text-grey-600">{perspective.memberNickname}</span>
                     </ExcerptBlock>
-                    <p className="typo-body1 text-grey-800">{perspective.impressiveReason}</p>
+                    <p className="typo-body1 text-grey-800 whitespace-pre-wrap">
+                      {perspective.impressiveReason}
+                    </p>
                   </div>
                 ))}
               </div>
@@ -80,8 +86,8 @@ const MeetingRetrospectiveItem = ({ record, onEdit, onDelete }: MeetingRetrospec
           <div key={`free-${idx}`} className="flex flex-col">
             {(topicGroups.length > 0 || idx > 0) && <Division className="mt-medium mb-large" />}
             <div className="flex flex-col gap-small">
-              <h5 className="typo-subtitle2 text-grey-800">{text.title}</h5>
-              <p className="typo-body1 text-black">{text.content}</p>
+              <h5 className="typo-subtitle2 text-grey-800 whitespace-pre-wrap">{text.title}</h5>
+              <p className="typo-body1 text-black whitespace-pre-wrap">{text.content}</p>
             </div>
           </div>
         ))}

--- a/src/features/book/components/PersonalRecordItem.tsx
+++ b/src/features/book/components/PersonalRecordItem.tsx
@@ -52,7 +52,7 @@ const PersonalRecordItem = ({ record, onEdit, onDelete }: PersonalRecordItemProp
         )}
 
         {/* 개인 감상/메모 */}
-        <p className="typo-body1 text-grey-800">{record.recordContent}</p>
+        <p className="typo-body1 text-grey-800 whitespace-pre-wrap">{record.recordContent}</p>
       </div>
     </FoldedCard>
   )

--- a/src/features/book/components/PersonalRecordModal.tsx
+++ b/src/features/book/components/PersonalRecordModal.tsx
@@ -9,6 +9,7 @@ import type {
 import { useCreateBookRecord, useUpdateBookRecord } from '@/features/book/hooks'
 import { cn } from '@/shared/lib/utils'
 import { Button } from '@/shared/ui/Button'
+import { useGlobalModalStore } from '@/store'
 import { Input } from '@/shared/ui/Input'
 import {
   Modal,
@@ -114,6 +115,8 @@ function PersonalRecordModal({
     personalBookId,
     record?.recordId ?? 0
   )
+  const { openAlert } = useGlobalModalStore()
+
   const resetForm = () => {
     setMemoContent('')
     setQuoteContent('')
@@ -130,6 +133,20 @@ function PersonalRecordModal({
 
   const handleSave = () => {
     if (mode === 'edit' && !record) return
+
+    if (recordType === 'MEMO' && !memoContent.trim()) {
+      openAlert('입력 필요', '메모 내용을 입력해주세요.')
+      return
+    }
+    if (recordType === 'QUOTE' && !quoteContent.trim()) {
+      openAlert('입력 필요', '기억하고 싶은 문장을 입력해주세요.')
+      return
+    }
+    if (recordType === 'QUOTE' && !pageNumber.trim()) {
+      openAlert('입력 필요', '페이지 번호를 입력해주세요.')
+      return
+    }
+
     const body: CreateBookRecordBody | UpdateBookRecordBody =
       recordType === 'MEMO'
         ? { recordType: 'MEMO', recordContent: memoContent }

--- a/src/features/book/components/PersonalRecordModal.tsx
+++ b/src/features/book/components/PersonalRecordModal.tsx
@@ -9,7 +9,6 @@ import type {
 import { useCreateBookRecord, useUpdateBookRecord } from '@/features/book/hooks'
 import { cn } from '@/shared/lib/utils'
 import { Button } from '@/shared/ui/Button'
-import { useGlobalModalStore } from '@/store'
 import { Input } from '@/shared/ui/Input'
 import {
   Modal,
@@ -20,6 +19,7 @@ import {
   ModalTitle,
 } from '@/shared/ui/Modal'
 import { Textarea } from '@/shared/ui/Textarea'
+import { useGlobalModalStore } from '@/store'
 
 type PersonalRecordModalProps = {
   open: boolean

--- a/src/features/book/hooks/useBookDetail.ts
+++ b/src/features/book/hooks/useBookDetail.ts
@@ -78,6 +78,7 @@ export function useToggleBookReadingStatus(bookId: number, personalBookId: numbe
     },
     onSuccess: (data) => {
       queryClient.setQueryData(bookKeys.detail(bookId), data)
+      queryClient.invalidateQueries({ queryKey: bookKeys.all })
     },
   })
 }

--- a/src/features/book/hooks/useBookRecords.ts
+++ b/src/features/book/hooks/useBookRecords.ts
@@ -27,7 +27,7 @@ export const bookRecordsKeys = {
  * ```tsx
  * function BookLogList({ bookId }: { bookId: number }) {
  *   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
- *     useBookRecords(bookId, { sort: 'LATEST' })
+ *     useBookRecords(bookId, { sort: 'DESC' })
  *
  *   const records = data?.pages.flatMap(page => page.items) ?? []
  *

--- a/src/features/book/hooks/useBooks.ts
+++ b/src/features/book/hooks/useBooks.ts
@@ -53,6 +53,7 @@ export function useBooks(
     queryKey: bookListKeys.list(params),
     queryFn: ({ pageParam }) =>
       getBooks({
+        size: 15,
         ...params,
         cursorRating: pageParam?.rating,
         cursorAddedAt: pageParam?.addedAt,

--- a/src/features/retrospectives/personal/components/PersonalRetrospectiveContent.tsx
+++ b/src/features/retrospectives/personal/components/PersonalRetrospectiveContent.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { cn } from '@/shared/lib/utils'
 import { Button, TextButton } from '@/shared/ui'
 
 import type { SectionKey } from '../hooks/usePersonalRetrospectiveForm'
@@ -97,7 +98,7 @@ export default function PersonalRetrospectiveContent({
             variant="secondary"
             outline
             onClick={() => setIsDropdownOpen((prev) => !prev)}
-            className="w-full"
+            className="w-full h-auto py-base typo-body2"
           >
             + 문항 추가하기
           </Button>
@@ -105,14 +106,19 @@ export default function PersonalRetrospectiveContent({
           {isDropdownOpen && (
             <>
               <div className="fixed inset-0 z-10" onClick={() => setIsDropdownOpen(false)} />
-              <div className="flex flex-col py-tiny absolute top-full left-0 right-0 mt-base z-20 overflow-hidden rounded-base border border-grey-300 bg-white shadow-drop">
-                {availableOptions.map(({ type, label }) => (
+              <div className="flex flex-col absolute top-full left-0 right-0 mt-base z-20 overflow-hidden rounded-base bg-white shadow-drop">
+                {availableOptions.map(({ type, label }, index) => (
                   <TextButton
                     key={type}
                     onClick={() => handleAddSection(type)}
-                    className="px-base py-xsmall text-black"
+                    className={cn(
+                      'px-medium py-base text-black hover:bg-grey-300 typo-subtitle4',
+                      index > 0 && 'border-t border-grey-400',
+                      index === 0 && 'rounded-t-base',
+                      index === availableOptions.length - 1 && 'rounded-b-base'
+                    )}
                   >
-                    {label}
+                    + {label}
                   </TextButton>
                 ))}
               </div>

--- a/src/pages/Books/BookListPage.tsx
+++ b/src/pages/Books/BookListPage.tsx
@@ -138,34 +138,36 @@ export default function BookListPage() {
     return (
       <div>
         <SubPageHeader label="내 책장" to={ROUTES.BOOKS} />
-        <div className="flex justify-between items-center pb-tiny mb-[37px]">
-          <h3 className="typo-heading3 text-black">내 책장 편집하기</h3>
-          <div className="flex gap-xsmall items-center">
-            <TextButton onClick={handleSelectAll}>
-              {isAllSelected ? '전체해제' : '전체선택'}
-            </TextButton>
-            <TextButton
-              onClick={handleDelete}
-              disabled={selectedBookIds.size === 0}
-              className="text-grey-700"
-            >
-              삭제하기
-            </TextButton>
+        <div className="mx-auto max-w-layout-max px-layout-padding">
+          <div className="flex justify-between items-center pb-tiny mb-[37px]">
+            <h3 className="typo-heading3 text-black">내 책장 편집하기</h3>
+            <div className="flex gap-xsmall items-center">
+              <TextButton onClick={handleSelectAll}>
+                {isAllSelected ? '전체해제' : '전체선택'}
+              </TextButton>
+              <TextButton
+                onClick={handleDelete}
+                disabled={selectedBookIds.size === 0}
+                className="text-grey-700"
+              >
+                삭제하기
+              </TextButton>
+            </div>
           </div>
+          <p className="typo-subtitle1 text-grey-700">{selectedBookIds.size}개 선택</p>
+          <BookList
+            isEditMode
+            selectedBookIds={selectedBookIds}
+            onSelectToggle={handleSelectToggle}
+            onFilteredBooksChange={handleFilteredBooksChange}
+          />
         </div>
-        <p className="typo-subtitle1 text-grey-700">{selectedBookIds.size}개 선택</p>
-        <BookList
-          isEditMode
-          selectedBookIds={selectedBookIds}
-          onSelectToggle={handleSelectToggle}
-          onFilteredBooksChange={handleFilteredBooksChange}
-        />
       </div>
     )
   }
 
   return (
-    <div>
+    <div className="mx-auto max-w-layout-max px-layout-padding">
       <h1 className="typo-heading1 text-black mt-xlarge mb-medium">내 책장</h1>
       <Tabs value={activeTab} onValueChange={handleTabChange}>
         <div className="flex justify-between items-center">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -79,7 +79,6 @@ export const router = createBrowserRouter([
             children: [
               { path: ROUTES.HOME, element: <HomePage /> },
               { path: ROUTES.HOME_ALIAS, element: <Navigate to={ROUTES.HOME} replace /> },
-              { path: ROUTES.BOOKS, element: <BookListPage /> },
               { path: ROUTES.GATHERINGS, element: <GatheringListPage /> },
               { path: ROUTES.GATHERING_CREATE, element: <CreateGatheringPage /> },
               { path: ROUTES.RECORDS, element: <RecordListPage /> },
@@ -91,6 +90,7 @@ export const router = createBrowserRouter([
             element: <FullWidthLayout />,
             children: [
               // 도서
+              { path: ROUTES.BOOKS, element: <BookListPage /> },
               { path: `${ROUTES.BOOKS}/:id`, element: <BookDetailPage /> },
               { path: `${ROUTES.BOOKS}/:id/reviews`, element: <BookReviewHistoryPage /> },
               // 모임

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -222,6 +222,24 @@
   }
 }
 
+@utility custom-scroll-grey200 {
+  &::-webkit-scrollbar {
+    /* ✅ 전체 영역 6+8+8 */
+    width: 22px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    /* ✅ 실제 보이는 thumb */
+    background-color: var(--color-grey-400);
+    border-radius: 30px;
+    border: 8px solid var(--color-grey-200);
+  }
+}
+
 @utility select-scroll-visible {
   /* shadcn select는 런타임에 스크롤을 숨기기 때문에 important사용*/
   scrollbar-width: auto !important;

--- a/src/shared/ui/Textarea.tsx
+++ b/src/shared/ui/Textarea.tsx
@@ -110,9 +110,9 @@ function Textarea({
         style={computedStyle}
         className={cn(
           textareaVariants({ state: error ? 'error' : 'default' }),
-          'custom-scroll',
-          disabled && 'pointer-events-none border-0 bg-grey-300 text-grey-700',
-          format === 'comment' && 'overflow-y-auto',
+          disabled ? 'custom-scroll-grey200' : 'custom-scroll',
+          'overflow-y-auto',
+          disabled && 'border-0 bg-grey-300 text-grey-700',
           className
         )}
         {...props}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

QA 2차 피드백에 따른 책 목록/상세, 감상기록, 개인 회고 영역의 버그 수정 및 UI 개선 작업입니다.
## 🔧 변경 사항

- 별점 필터 적용 시 0.5점 단위 별점(예: 3.5)도 함께 조회되도록 maxRating을 .9까지 확장
- 기록 완료 상태일 때 '기록 추가하기' 버튼이 보이지 않도록 isRecording 조건 추가
- 정렬 탭 값을 LATEST/OLDEST → DESC/ASC로 변경
- 내 책장 무한스크롤 페이지 사이즈를 BE 기준에 맞게 15개로 수정
- 책 기록 타임라인 정렬 타입(RecordSortType)을 BE API 변경에 맞춰 LATEST/OLDEST → DESC/ASC로 수정 (예시 코드, mock 필터링 로직 포함)
- 책 기록 상태 토글 후 내 책장으로 이동했을 때 기록 중 on/off가 즉시 반영되도록 useToggleBookReadingStatus 성공 시 bookKeys.all 쿼리 무효화 추가
- disabled 상태 Textarea의 스크롤 동작 수정 및 스크롤바 배경색 보정을 위한 custom-scroll-grey200 유틸리티 추가
- 개인 감상기록 생성/수정 시 메모, 인용 문장, 페이지 번호 등 필수값 미입력 상태에서 alert 모달 노출하도록 검증 로직 추가
- 내 책장 편집하기 화면에서 헤더/리스트 정렬이 틀어지던 문제 수정 (레이아웃 컨테이너 적용)
- BOOKS 라우트를 FullWidthLayout 하위로 이동
- 개인/모임 감상기록의 줄바꿈이 화면에 그대로 반영되도록 whitespace-pre-wrap 적용
- 개인 회고 문항 추가하기 드롭다운 버튼 및 옵션 항목 디자인 변경 (간격, 타이포, hover 스타일, 둥근 모서리 처리)

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

- 책 상세페이지 기록 타임라인에서의 모임 필터링에 대하여 백엔드 api 변경 완료 후 추가 작업하여 해당 pr에 포함시킬 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 저장 전 필수 입력값 검증 기능 추가
  * 텍스트의 줄바꿈과 공백이 보존되어 표시되도록 개선

* **Bug Fixes**
  * 도서 평점 필터 검색 범위 확장 (0.5 단위 포함)

* **Improvements**
  * 정렬 옵션 표시 개선 (DESC/ASC)
  * 무한스크롤 페이지 로드 최적화
  * UI 레이아웃 및 드롭다운 디자인 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->